### PR TITLE
Use GITHUB_TOKEN instead of GLOBAL_GHA_PAT in hello.yaml

### DIFF
--- a/.github/workflows/hello.yaml
+++ b/.github/workflows/hello.yaml
@@ -6,10 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         name: send-message
         with:
-          github-token: ${{ secrets.GLOBAL_GHA_PAT }}
           script: |
             await github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -17,4 +16,3 @@ jobs:
               repo: context.repo.repo,
               body: `Hey, thank you for opening your Pull Request ! 🙂 We will get to this as soon as we can!`
             })
-


### PR DESCRIPTION
## Summary
- Remove `GLOBAL_GHA_PAT` from `hello.yaml` since this workflow only comments on PRs in the same repo
- The default `GITHUB_TOKEN` has sufficient permissions for this
- Also bumps `actions/github-script` from v6 to v7

## Why
Reduces exposure of the org-wide PAT. The `github-token` parameter defaults to `GITHUB_TOKEN` when omitted, so removing the explicit `github-token` line is all that's needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)