### PR TITLE
Discover packages from blog authors and fix README rendering

### DIFF
--- a/.github/workflows/knit_readme.yaml
+++ b/.github/workflows/knit_readme.yaml
@@ -1,8 +1,15 @@
-name: Knit readme
+name: Knit readme and aggregate website JSONs
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
+    paths:
+      - 'data/content/**'
+      - 'data/packages/**'
+      - 'README.Rmd'
+      - 'scripts/generate_website_jsons.R'
+      - '.github/workflows/knit_readme.yaml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,8 +43,8 @@ jobs:
         run: rmarkdown::render("README.Rmd", output_format = "github_document")
         shell: Rscript {0}
 
-      - name: Update aggregated files
-        run: Rscript -e 'source("scripts/generate_website_jsons.R")'
+      - name: Aggregate website JSONs
+        run: source("scripts/generate_website_jsons.R")
         shell: Rscript {0}
 
       - name: Commit data
@@ -46,6 +53,6 @@ jobs:
         run: |
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git commit README.md -m 'Update README list' || echo "No changes to commit"
-          git commit data/website -m 'Update website data' || echo "No changes to commit"
+          git add README.md data/website
+          git diff --cached --quiet || git commit -m 'Update README and aggregated website JSONs'
           git push origin || echo "Nothing to push"

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,10 +16,10 @@ knitr::opts_chunk$set(
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
-Curated lists of R-Ladies community resources (blogs, YouTube channels, and R packages currently). 
-Each entry is stored as a JSON metadata file in this repository; the site-friendly aggregated JSON files are generated into the `website/` directory by the script `scripts/generate_website_jsons.R`.
+Curated lists of R-Ladies community resources (blogs, YouTube channels, and R packages currently).
+Each entry is stored as a JSON metadata file in this repository; the site-friendly aggregated JSON files are generated into the `data/website/` directory by the script `scripts/generate_website_jsons.R`.
 
-To contribute: add a JSON file describing the blog (to `content/`) or the package (to `packages/`) following the examples in the repository and the JSON schema at `scripts/json_schema/`.
+To contribute: add a JSON file describing the blog (to `data/content/`) or the package (to `data/packages/`) following the examples in the repository and the JSON schema at `scripts/json_schema/`.
 
 See `CONTRIBUTING.md` for style and metadata conventions.
 
@@ -27,22 +27,23 @@ See `CONTRIBUTING.md` for style and metadata conventions.
 
 Created from the JSON files in `data/content/` (one JSON per blog). The aggregated file is written to `data/website/awesome_content.json`.
 ```{r, echo = FALSE, results='asis'}
+coalesce <- function(...) {
+  for (v in list(...)) if (!is.null(v) && nzchar(v)) return(v)
+  ""
+}
+
+author_names <- function(authors) {
+  paste(vapply(authors, function(a) a$name %||% "", character(1)), collapse = ", ")
+}
+
 json_list <- list.files(here::here("data/content"), "json$", full.names = TRUE)
 dt <- lapply(json_list, jsonlite::read_json)
 
-invisible(
-  lapply(dt, function(x) {
-    cat(
-      sprintf(
-        " - [%s](%s) by %s",
-        x$title,
-        x$url,
-        paste(sapply(x$authors, function(x) x$name), collapse = ", ")
-      ),
-      sep = "\n"
-    )
-  })
-)
+bullets <- vapply(dt, function(x) {
+  sprintf("- [%s](%s) by %s", x$title, coalesce(x$url), author_names(x$authors))
+}, character(1))
+
+cat("\n", bullets, sep = "\n")
 ```
 
 ## List of packages
@@ -52,19 +53,12 @@ Created from the JSON files in `data/packages/` (one JSON per package). The aggr
 json_list <- list.files(here::here("data/packages"), "json$", full.names = TRUE)
 dt <- lapply(json_list, jsonlite::read_json)
 
-invisible(
-  lapply(dt, function(x) {
-    cat(
-      sprintf(
-        " - [%s](%s) by %s",
-        x$name,
-        x$repo_url,
-        paste(sapply(x$maintainers, function(x) x$name), collapse = ", ")
-      ),
-      sep = "\n"
-    )
-  })
-)
+bullets <- vapply(dt, function(x) {
+  url <- coalesce(x$repo_url, x$pkdown_url, x$bug_reports_url)
+  sprintf("- [%s](%s) by %s", x$name, url, author_names(x$authors))
+}, character(1))
+
+cat("\n", bullets, sep = "\n")
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,88 +1,335 @@
 
-
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
 # Awesome R-Ladies’ Content and Packages
 
-[![](https://awesome.re/badge.svg)](https://awesome.re)
+[![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 Curated lists of R-Ladies community resources (blogs, YouTube channels,
 and R packages currently). Each entry is stored as a JSON metadata file
 in this repository; the site-friendly aggregated JSON files are
-generated into the `website/` directory by the script
+generated into the `data/website/` directory by the script
 `scripts/generate_website_jsons.R`.
 
-To contribute: add a JSON file describing the blog (to `content/`) or
-the package (to `packages/`) following the examples in the repository
-and the JSON schema at `scripts/json_schema/`.
+To contribute: add a JSON file describing the blog (to `data/content/`)
+or the package (to `data/packages/`) following the examples in the
+repository and the JSON schema at `scripts/json_schema/`.
 
 See `CONTRIBUTING.md` for style and metadata conventions.
 
 ## List of blogs
 
 Created from the JSON files in `data/content/` (one JSON per blog). The
-aggregated file is written to `data/website/awesome_content.json`. -
-[Amanda’s Data Blog](amanda.rbind.io) by Amanda Peterson - [Very
-Statisticious](https://aosmith.rbind.io) by Ariel Muldoon - [Alison
-Hill](https://www.apreshill.com) by Alison Hill - [Beatriz Milz’s
-blog](https://beatrizmilz.com/) by Beatriz Milz - [Notes from a data
-witch](https://blog.djnavarro.net/) by Danielle Navarro - [Building
-Stories with Data](https://cararthompson.com/blog) by Cara Thompson -
-[Crystal Lewis](https://www.cghlewis.com) by Crystal Lewis - [Citizen
-Statistician](citizen-statistician.org) by Mine Çetinkaya-Rundel, Rob
-Gould, Andrew Zieffler - [Cosima Meyer](https://cosimameyer.com/) by
-Cosima Meyer - [Darya Vanichkina’s
-blog](https://www.daryavanichkina.com/posts.html) by Darya Vanichkina -
-[Data Pedagogy](https://www.datapedagogy.com/) by Mine Dogucu -
-[Dr. Mowinckel’s blog](https://drmowinckels.io) by Athanasia Monika
-Mowinckel - [Elena Dudukina’s blog](https://elenadudukina.com) by Elena
-Dudukina - [Ella Kaye](https://ellakaye.co.uk) by Ella Kaye - [Emily
-Riederer](https://emilyriederer.com) by Emily Riederer - [Federica
-Gazzelloni](https://fgazzelloni.quarto.pub) by Federica Gazzelloni -
-[Florencia D’Andrea](https://florenciadandrea.com) by Florencia
-D’Andrea -
-[Hypebright](https://hypebright.nl/index.php/en/home-en/blog/) by Veerle
-van Leemput - [Isabel Zimmerman](https://isabelizimm.github.io/) by
-Isabel Zimmerman - [%\>% Dreams](https://ivelasq.rbind.io/) by Isabella
-Velásquez - [data whiskeRs](https://jadeyryan.com/blog) by Jadey Ryan -
-[Data in life](https://jhylin.github.io/Data_in_life_blog/) by Jennifer
-HY Lin - [Julia Silge](https://juliasilge.com/) by Julia Silge - [Karina
-Bartolome](https://karbartolome-blog.netlify.app) by Karina Bartolome -
-[Once Upon a Time
-Series](https://lgibson7.quarto.pub/once-upon-a-time-series/) by Lydia
-Gibson - [Lore Abad](https://loreabad6.github.io/) by Lorena Abad -
-[Macarena Quiroga](https://macarenaquiroga.netlify.app) by Macarena
-Quiroga - [Maëlle’s R blog](https://masalmon.eu/) by Maëlle Salmon -
-[Nicola Rennie](https://nrennie.rbind.io) by Nicola Rennie - [Piping Hot
-Data](https://www.pipinghotdata.com) by Shannon Pileggi - [R-Ladies
-Gaborone](https://r-ladiesgaborone2021.quarto.pub) by R-Ladies
-Gabarone - [R-Ladies Melbourne
-Blog](https://r-ladiesmelbourne.github.io/) by R-Ladies Melbourde -
-[R-Ladies São Paulo Blog](https://rladies-sp.org/) by R-Ladies São
-Paulo - [Data Science
-Blog](https://sabrinaschalz.wordpress.com/data-science-blog/) by Sabrina
-Schalz - [Sarah Gillespie’s blog](https://sarahgillespie.github.io/SG/)
-by Sarah Gillespie - [Sam Tyner-Monroe](https://sctyner.me) by Sam
-Tyner-Monroe - [Shel Kariuki’s blog](https://shelkariuki.netlify.app/)
-by Shel Kariuki - [Meeting People Where They
-R](https://silviacanelon.com) by Silvia Canelón - [Soy Andrea
-blog](https://soyandrea.netlify.app/) by Andrea Gómez Vargas - [Ciencia
-de Datos en Español](https://sporella.xyz) by Steph Orellana Bello -
-[Steffi LaZerte](https://steffilazerte.ca/tips_and_tricks.html) by
-Steffi LaZerte - [Surrounded by
-Data](https://surroundedbydata.netlify.app/) by Veerle van Son -
-[Exploration Corner](https://thetidytrekker.com/blog.html) by Meghan
-Harris - [Yanina Bellini Saibene](https://yabellini.netlify.app/blog/)
-by Yanina Bellini Saibene - [Melissa Van Bussel (ggnot2)’s YouTube
-channel about R](https://www.youtube.com/c/ggnot2) by Melissa Van Bussel
+aggregated file is written to `data/website/awesome_content.json`.
+
+- [Amanda’s Data Blog](amanda.rbind.io) by Amanda Peterson
+- [Very Statisticious](https://aosmith.rbind.io) by Ariel Muldoon
+- [Alison Hill](https://www.apreshill.com) by Alison Hill
+- [Beatriz Milz’s blog](https://beatrizmilz.com/) by Beatriz Milz
+- [Notes from a data witch](https://blog.djnavarro.net/) by Danielle
+  Navarro
+- [Building Stories with Data](https://cararthompson.com/blog) by Cara
+  Thompson
+- [Crystal Lewis](https://www.cghlewis.com) by Crystal Lewis
+- [Citizen Statistician](citizen-statistician.org) by Mine
+  Çetinkaya-Rundel, Rob Gould, Andrew Zieffler
+- [Cosima Meyer](https://cosimameyer.com/) by Cosima Meyer
+- [Darya Vanichkina’s blog](https://www.daryavanichkina.com/posts.html)
+  by Darya Vanichkina
+- [Data Pedagogy](https://www.datapedagogy.com/) by Mine Dogucu
+- [Dr. Mowinckel’s blog](https://drmowinckels.io) by Athanasia Monika
+  Mowinckel
+- [Elena Dudukina’s blog](https://elenadudukina.com) by Elena Dudukina
+- [Ella Kaye](https://ellakaye.co.uk) by Ella Kaye
+- [Emily Riederer](https://emilyriederer.com) by Emily Riederer
+- [Federica Gazzelloni](https://fgazzelloni.quarto.pub) by Federica
+  Gazzelloni
+- [Florencia D’Andrea](https://florenciadandrea.com) by Florencia
+  D’Andrea
+- [Hypebright](https://hypebright.nl/index.php/en/home-en/blog/) by
+  Veerle van Leemput
+- [Isabel Zimmerman](https://isabelizimm.github.io/) by Isabel Zimmerman
+- [%\>% Dreams](https://ivelasq.rbind.io/) by Isabella Velásquez
+- [data whiskeRs](https://jadeyryan.com/blog) by Jadey Ryan
+- [Data in life](https://jhylin.github.io/Data_in_life_blog/) by
+  Jennifer HY Lin
+- [Julia Silge](https://juliasilge.com/) by Julia Silge
+- [Karina Bartolome](https://karbartolome-blog.netlify.app) by Karina
+  Bartolome
+- [Once Upon a Time
+  Series](https://lgibson7.quarto.pub/once-upon-a-time-series/) by Lydia
+  Gibson
+- [Lore Abad](https://loreabad6.github.io/) by Lorena Abad
+- [Macarena Quiroga](https://macarenaquiroga.netlify.app) by Macarena
+  Quiroga
+- [Maëlle’s R blog](https://masalmon.eu/) by Maëlle Salmon
+- [Nicola Rennie](https://nrennie.rbind.io) by Nicola Rennie
+- [Piping Hot Data](https://www.pipinghotdata.com) by Shannon Pileggi
+- [R-Ladies Gaborone](https://r-ladiesgaborone2021.quarto.pub) by
+  R-Ladies Gabarone
+- [R-Ladies Melbourne Blog](https://r-ladiesmelbourne.github.io/) by
+  R-Ladies Melbourde
+- [R-Ladies São Paulo Blog](https://rladies-sp.org/) by R-Ladies São
+  Paulo
+- [Data Science
+  Blog](https://sabrinaschalz.wordpress.com/data-science-blog/) by
+  Sabrina Schalz
+- [Sarah Gillespie’s blog](https://sarahgillespie.github.io/SG/) by
+  Sarah Gillespie
+- [Sam Tyner-Monroe](https://sctyner.me) by Sam Tyner-Monroe
+- [Shel Kariuki’s blog](https://shelkariuki.netlify.app/) by Shel
+  Kariuki
+- [Meeting People Where They R](https://silviacanelon.com) by Silvia
+  Canelón
+- [Soy Andrea blog](https://soyandrea.netlify.app/) by Andrea Gómez
+  Vargas
+- [Ciencia de Datos en Español](https://sporella.xyz) by Steph Orellana
+  Bello
+- [Steffi LaZerte](https://steffilazerte.ca/tips_and_tricks.html) by
+  Steffi LaZerte
+- [Surrounded by Data](https://surroundedbydata.netlify.app/) by Veerle
+  van Son
+- [Exploration Corner](https://thetidytrekker.com/blog.html) by Meghan
+  Harris
+- [Yanina Bellini Saibene](https://yabellini.netlify.app/blog/) by
+  Yanina Bellini Saibene
+- [Melissa Van Bussel (ggnot2)’s YouTube channel about
+  R](https://www.youtube.com/c/ggnot2) by Melissa Van Bussel
 
 ## List of packages
 
 Created from the JSON files in `data/packages/` (one JSON per package).
-The aggregated file is written to
-`data/website/awesome_packages.json`. -
-[meetupr](https://github.com/rladies/meetupr) by R-Ladies Global
+The aggregated file is written to `data/website/awesome_packages.json`.
+
+- [airports](https://github.com/OpenIntroStat/airports) by Mine
+  Çetinkaya-Rundel
+- [aperol](https://github.com/EllaKaye/aperol) by Ella Kaye, Kelly
+  Bodwin, Collin Schwantes
+- [artpack](https://github.com/Meghansaha/artpack) by Meghan Harris
+- [arttools](https://github.com/djnavarro/arttools) by Danielle Navarro
+- [ARUtools](https://github.com/ARUtools/ARUtools) by David Hope, Steffi
+  LaZerte, Government of Canada
+- [asciify](https://github.com/djnavarro/asciify) by Danielle Navarro
+- [bakeoff](https://github.com/apreshill/bakeoff) by Alison Hill,
+  Chester Ismay, Richard Iannone
+- [basepenguins](https://github.com/EllaKaye/basepenguins) by Ella Kaye,
+  Heather Turner, Achim Zeileis
+- [BayesERtools](https://genentech.github.io/BayesERtools/) by Kenta
+  Yoshida, François Mercier, Danielle Navarro, Genentech, Inc.
+- [bayesrules](https://github.com/bayes-rules/bayesrules/) by Mine
+  Dogucu, Alicia Johnson, Miles Ott
+- [bcaquiferdata](https://github.com/bcgov/bcaquiferdata) by Steffi
+  LaZerte, Christine Bieber, Province of British Columbia
+- [bcgwcat](https://github.com/bcgov/bcgwcat/) by Steffi LaZerte,
+  Andarge Baye, Province of British Columbia
+- [bcgwlreports](https://github.com/bcgov/bcgwlreports) by Steffi
+  LaZerte, Jon Goetz
+- [BradleyTerryScalable](https://github.com/EllaKaye/BradleyTerryScalable)
+  by Ella Kaye, David Firth
+- [bs4cards](https://github.com/djnavarro/bs4cards) by Danielle Navarro
+- [bundle](https://github.com/rstudio/bundle) by Julia Silge, Simon
+  Couch, Qiushi Yan, Max Kuhn, Posit Software, PBC
+- [butcher](https://github.com/tidymodels/butcher) by Joyce Cahoon,
+  Davis Vaughan, Max Kuhn, Alex Hayes, Julia Silge, Posit Software, PBC
+- [capesData]() by Leonardo Biazoli, Mine Çetinkaya-Rundel, Eric
+  Fernandes de Mello Araujo, Izabela R. Cardoso de Oliveira
+- [cereal](https://github.com/r-lib/cereal/) by Julia Silge, Davis
+  Vaughan, Posit Software, PBC
+- [cherryblossom](https://github.com/OpenIntroStat/cherryblossom) by
+  Mine Çetinkaya-Rundel
+- [codemeta](https://github.com/cboettig/codemeta) by Carl Boettiger,
+  Maëlle Salmon, Katrin Leinweber, Noam Ross, Arfon Smith, Jeroen Ooms,
+  Sebastian Meyer, Michael Rustler, Hauke Sonnenberg, Sebastian
+  Kreutzer, rOpenSci
+- [codemetar](https://github.com/ropensci/codemetar) by Carl Boettiger,
+  Anna Krystalli, Toph Allen, Maëlle Salmon, rOpenSci, Katrin Leinweber,
+  Noam Ross, Arfon Smith, Jeroen Ooms, Sebastian Meyer, Michael Rustler,
+  Hauke Sonnenberg, Sebastian Kreutzer, Thierry Onkelinx
+- [colorhex](https://github.com/drmowinckels/colorhex) by Athanasia Mo
+  Mowinckel, Julia Romanowska
+- [cransays](https://github.com/r-hub/cransays) by Hugo Gruson, Maëlle
+  Salmon, Locke Data, Stephanie Locke, Mitchell O’Hara-Wild, Lluís
+  Revilla Sancho, Jim Hester, Hadley Wickham
+- [dados](https://github.com/cienciadedatos/dados) by Riva Quiroga, Sara
+  Mortara, Beatriz Milz, Andrea Sánchez-Tapia, Alejandra Andrea Tapia
+  Silva, Beatriz Maurer Costa, Jean Prado, Renata Hirota, William
+  Amorim, Emmanuelle Rodrigues Nunes
+- [dataspice](https://github.com/ropensci/dataspice) by Carl Boettiger,
+  Scott Chamberlain, Auriel Fournier, Kelly Hondula, Anna Krystalli,
+  Bryce Mecum, Maëlle Salmon, Kate Webbink, Kara Woo, Irene Steves
+- [emodnet.wfs](https://github.com/EMODnet/emodnet.wfs) by Joana Beja,
+  Anna Krystalli, Salvador Fernández-Bejarano, Thomas J Webb, European
+  Marine Observation Data Network, VLIZ, Maëlle Salmon, Alec L.
+  Robitaille, Liz Hare, François Michonneau
+- [flametree](https://github.com/djnavarro/flametree) by Danielle
+  Navarro
+- [ggauto](https://github.com/nrennie/ggauto) by Nicola Rennie
+- [ggflowchart](https://github.com/nrennie/ggflowchart) by Nicola Rennie
+- [ggPMX](https://github.com/ggPMXdevelopment/ggPMX) by Amine Gassem,
+  Bruno Bieth, Irina Baltcheva, Thomas Dumortier, Christian Bartels,
+  Souvik Bhattacharya, Inga Ludwig, Ines Paule, Didier Renard, Matthew
+  Fidler, Seid Hamzic, Benjamin Guiastrennec, Kyle T Baron, Qing Xi Ooi,
+  Aleksandr Pogodaev, Danielle Navarro, Ibtissem Rebai, Mahmoud Ali,
+  Novartis Pharma AG
+- [ghclass](https://github.com/rundel/ghclass) by Colin Rundel, Mine
+  Cetinkaya-Rundel, Therese Anders
+- [glitter](https://github.com/lvaudor/glitter) by Lise Vaudor, Maëlle
+  Salmon
+- [gtreg](https://github.com/shannonpileggi/gtreg) by Shannon Pileggi,
+  Daniel D. Sjoberg
+- [hellodatascience](https://github.com/hellodata-science/hellodatascience)
+  by Mine Dogucu, Catalina Medina, Alma Castro
+- [hexify](https://github.com/djnavarro/hexify) by Danielle Navarro
+- [hmsidwR](https://github.com/Fgazzelloni/hmsidwR) by Federica
+  Gazzelloni
+- [igraph](https://github.com/igraph/rigraph) by Gábor Csárdi, Tamás
+  Nepusz, Vincent Traag, Szabolcs Horvát, Fabio Zanini, Daniel Noom,
+  Kirill Müller, Michael Antonov, Chan Zuckerberg Initiative, David
+  Schoch, Maëlle Salmon, R Consortium
+- [infer](https://github.com/tidymodels/infer) by Andrew Bray, Chester
+  Ismay, Evgeni Chasnovski, Simon Couch, Ben Baumer, Mine
+  Cetinkaya-Rundel, Ted Laderas, Nick Solomon, Johanna Hardin, Albert Y.
+  Kim, Neal Fultz, Doug Friedman, Richie Cotton, Brian Fannin
+- [janeaustenr](https://github.com/juliasilge/janeaustenr) by Julia
+  Silge
+- [jasmines](https://github.com/djnavarro/jasmines) by Danielle Navarro
+- [jaysire](https://github.com/djnavarro/jaysire) by Danielle Navarro,
+  Danielle Navarro
+- [learnres](https://github.com/yabellini/learnres) by Yanina Bellini
+  Saibene
+- [LITAP](https://github.com/FRDC-SHL/LITAP) by Steffi LaZerte, Sheng
+  Li, Agriculture and Agri-Food Canada
+- [lsr](https://github.com/djnavarro/lsr) by Danielle Navarro
+- [meetupr](https://github.com/rladies/meetupr) by Athanasia Mo
+  Mowinckel, Erin LeDell, Olga Mierzwa-Sulima, Lucy D’Agostino McGowan,
+  Claudia Vitolo, Gabriela De Queiroz, Michael Beigelmacher, Augustina
+  Ragwitz, Greg Sutcliffe, Rick Pack, Ben Ubah, Maëlle Salmon, Barret
+  Schloerke, R-Ladies Global
+- [messy](https://github.com/nrennie/messy) by Nicola Rennie
+- [MLDataR](https://github.com/StatsGary/MLDataR) by Gary Hutson, Asif
+  Laldin, Isabella Velásquez
+- [monochromeR](https://github.com/cararthompson/monochromeR) by Cara
+  Thompson
+- [MSUthemes](https://github.com/emilioxavier/MSUthemes) by Emilio
+  Xavier Esposito, Nicola Rennie, Michigan State University
+- [namer](https://github.com/jumpingrivers/namer) by Colin Gillespie,
+  Steph Locke, Maëlle Salmon, Ellis Valentiner, Charlie Hadley, Jumping
+  Rivers, Han Oostdijk, Patrick Schratz
+- [naturecounts](https://github.com/BirdsCanada/naturecounts) by Steffi
+  LaZerte, Denis Lepage
+- [odbr](https://github.com/hsvab/odbr) by Haydee Svab, Beatriz Milz,
+  Diego Rabatone Oliveira, Rafael H. M. Pereira
+- [opencage](https://github.com/ropensci/opencage) by Daniel
+  Possenriede, Jesse Sadler, Maëlle Salmon, Noam Ross, Jake Russ, Julia
+  Silge
+- [openintro](https://github.com/OpenIntroStat/openintro/) by Mine
+  Çetinkaya-Rundel, David Diez, Andrew Bray, Albert Y. Kim, Ben Baumer,
+  Chester Ismay, Nick Paterno, Christopher Barr
+- [osmdata](https://github.com/ropensci/osmdata) by Joan Maspons, Mark
+  Padgham, Bob Rudis, Robin Lovelace, Maëlle Salmon, Andrew Smith, James
+  Smith, Andrea Gilardi, Enrico Spinielli, Anthony North, Martin
+  Machyna, Marcin Kalicinski, Eli Pousson
+- [overviewR](https://github.com/cosimameyer/overviewR) by Cosima Meyer,
+  Dennis Hammerschmidt
+- [palmerpenguins](https://github.com/allisonhorst/palmerpenguins) by
+  Allison Horst, Alison Hill, Kristen Gorman
+- [parmsurvfit](https://github.com/apjacobson/parmsurvfit) by Ashley
+  Jacobson, Victor Wilson, Shannon Pileggi
+- [pins](https://github.com/rstudio/pins-r) by Julia Silge, Hadley
+  Wickham, Javier Luraschi, Posit Software, PBC
+- [pkgdown](https://github.com/r-lib/pkgdown) by Hadley Wickham, Jay
+  Hesselberth, Maëlle Salmon, Olivier Roy, Salim Brüggemann, Posit
+  Software, PBC
+- [pkgsearch](https://github.com/r-hub/pkgsearch) by Gábor Csárdi,
+  Maëlle Salmon, R Consortium
+- [pregnancy](https://github.com/EllaKaye/pregnancy) by Ella Kaye
+- [PrettyCols](https://github.com/nrennie/PrettyCols) by Nicola Rennie
+- [projmgr](https://github.com/emilyriederer/projmgr) by Emily Riederer
+- [quadkeyr](https://github.com/ropensci/quadkeyr) by Florencia
+  D’Andrea, Pilar Fernandez, Maria Paula Caldas, Vincent van Hees,
+  Andrew Pulsipher, CDC’s Center for Forecasting and Outbreak Analytics,
+  MIDAS-NIH COVID-19 urgent grant program, Paul G. Allen School for
+  Global Health, Washington State University
+- [qualtRics](https://github.com/ropensci/qualtRics) by Jasper Ginn,
+  Jackson Curtis, Shaun Jackson, Samuel Kaminsky, Eric Knudsen, Joseph
+  O’Brien, Daniel Seneca, Julia Silge, Phoebe Wong
+- [quartose](https://github.com/djnavarro/quartose) by Danielle Navarro
+- [queue](https://github.com/djnavarro/queue) by Danielle Navarro
+- [rainbowr](https://github.com/djnavarro/rainbowr) by Danielle Navarro
+- [rhub](https://github.com/r-hub/rhub) by Gábor Csárdi, Maëlle Salmon,
+  R Consortium
+- [riem](https://github.com/ropensci/riem) by Maëlle Salmon, Brooke
+  Anderson, CHAI Project, rOpenSci, Daryl Herzmann, Jonathan Elchison
+- [roblog](https://github.com/ropenscilabs/roblog) by Maëlle Salmon,
+  Stefanie Butland, rOpenSci, Amanda Dobbyn, Christophe Dervieux, Romain
+  LESUR
+- [rsample](https://github.com/tidymodels/rsample) by Hannah Frick,
+  Fanny Chow, Max Kuhn, Michael Mahoney, Julia Silge, Hadley Wickham,
+  Posit Software, PBC
+- [RSSthemes](https://github.com/nrennie/RSSthemes) by Nicola Rennie,
+  Royal Statistical Society
+- [rstanemax](https://github.com/yoshidk6/rstanemax) by Kenta Yoshida,
+  Danielle Navarro, Trustees of Columbia University
+- [sessioncheck](https://github.com/djnavarro/sessioncheck) by Danielle
+  Navarro
+- [sfnetworks](https://github.com/luukvdmeer/sfnetworks) by Lucas van
+  der Meer, Lorena Abad, Andrea Gilardi, Robin Lovelace
+- [shinyMobile](https://github.com/RinteRface/shinyMobile) by David
+  Granjon, Veerle van Leemput, AthlyticZ, Victor Perrier, John Coene,
+  Isabelle Rudolf, Dieter Menne, Marvelapp, Vladimir Kharlampidi
+- [shinymodels](https://github.com/tidymodels/shinymodels) by Max Kuhn,
+  Shisham Adhikari, Julia Silge, Simon Couch, Posit Software, PBC
+- [siga](https://github.com/AgRoMeteorologiaINTA/siga) by Yanina Bellini
+  Saibene, Elio Campitelli, Paola Corrales, Natalia Gattinoni, INTA
+- [SISINTAR](https://github.com/inta-suelos/SISINTAR) by Yanina Bellini
+  Saibene, Elio Campitelli, Paola Corrales
+- [spatialsample](https://github.com/tidymodels/spatialsample) by
+  Michael Mahoney, Julia Silge, Posit Software, PBC
+- [statsr](https://github.com/StatsWithR/statsr) by Colin Rundel, Mine
+  Cetinkaya-Rundel, Merlise Clyde, David Banks
+- [TextMiningTutorial](https://github.com/yabellini/TextMiningTutorial)
+  by Yanina Bellini Saibene
+- [tidylo](https://github.com/juliasilge/tidylo) by Tyler Schnoebelen,
+  Julia Silge, Alex Hayes
+- [tidyquintro](https://github.com/drmowinckels/tidyquintro) by
+  Athanasia Mo Mowinckel
+- [tidytext](https://github.com/juliasilge/tidytext) by Gabriela De
+  Queiroz, Colin Fay, Emil Hvitfeldt, Os Keyes, Kanishka Misra, Tim
+  Mastny, Jeff Erickson, David Robinson, Julia Silge
+- [tinkr](https://github.com/ropensci/tinkr) by Maëlle Salmon, Zhian N.
+  Kamvar, Jeroen Ooms, Nick Wellnhofer, rOpenSci, Peter Daengeli
+- [traudem](https://github.com/lucarraro/traudem) by Luca Carraro,
+  University of Zurich, Maëlle Salmon, Wael Sadek, Kirill Müller
+- [TutorialgRaficosFN](https://github.com/yabellini/TutorialgRaficosFN)
+  by Yanina Bellini Saibene, Yanina Bellini Saibene
+- [TutorialIterar](https://github.com/yabellini/TutorialIterar) by
+  Yanina Bellini Saibene
+- [typeR](https://github.com/Fgazzelloni/typeR) by Federica Gazzelloni
+- [uiothemes](https://github.com/drmowinckels/uiothemes) by Athanasia Mo
+  Mowinckel
+- [ukbabynames](https://github.com/mine-cetinkaya-rundel/ukbabynames) by
+  Mine Çetinkaya-Rundel, Thomas J. Leeper, Nicholas Goguen-Compagnoni,
+  Sara Lemus
+- [usdata](https://github.com/OpenIntroStat/usdata) by Mine
+  Çetinkaya-Rundel, David Diez, Leah Dorazio
+- [vcr](https://github.com/ropensci/vcr/) by Scott Chamberlain, Aaron
+  Wolen, Maëlle Salmon, Daniel Possenriede, Hadley Wickham, rOpenSci
+- [verbaliseR](https://github.com/cararthompson/verbaliseR) by Cara
+  Thompson
+- [vetiver](https://github.com/rstudio/vetiver-r/) by Julia Silge, Posit
+  Software, PBC
+- [washi](https://github.com/WA-Department-of-Agriculture/washi) by
+  Jadey Ryan, Molly McIlquham, Dani Gelardi, Washington State Department
+  of Agriculture
+- [weathercan](https://github.com/ropensci/weathercan/) by Steffi
+  LaZerte, Sam Albers, Nick Brown, Kevin Cazelles, Richard Littauer,
+  Shandiya Balasubramaniam, Mark Ciechanowski, Jeremy Selva, Kelli F.
+  Johnson, Russ Allen, Everett Snieder, Josh Persi, Mahjabin Oyshi
+- [widyr](https://github.com/juliasilge/widyr) by David Robinson,
+  Kanishka Misra, Julia Silge
+- [worrrd](https://github.com/anthonypileggi/worrrd) by Anthony Pileggi,
+  Shannon Pileggi
 
 ## License
 
-[![](https://upload.wikimedia.org/wikipedia/commons/6/69/CC0_button.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
+[![CC0](https://upload.wikimedia.org/wikipedia/commons/6/69/CC0_button.svg)](https://creativecommons.org/publicdomain/zero/1.0/)

--- a/data/packages/ARUtools.json
+++ b/data/packages/ARUtools.json
@@ -1,0 +1,36 @@
+{
+  "name": "ARUtools",
+  "title": "Management and Processing of Autonomous Recording Unit (ARU)\nData",
+  "description": "Parse Autonomous Recording Unit (ARU) data and for sub-sampling recordings. Extract Metadata from your recordings, select a subset of recordings for interpretation, and prepare files for processing on the 'WildTrax' <https://wildtrax.ca/> platform. Read and process metadata from recordings collected using the SongMeter and BAR-LT types of ARUs.",
+  "repo_url": "https://github.com/ARUtools/ARUtools",
+  "pkdown_url": "https://arutools.github.io/ARUtools/",
+  "bug_reports_url": "https://github.com/ARUtools/ARUtools/issues",
+  "logo_url": "https://arutools.github.io/ARUtools/logo.png",
+  "last_updated": "2025-07-28",
+  "authors": [
+    {
+      "name": "David Hope",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-2140-4261",
+      "email": "david.hope@ec.gc.ca"
+    },
+    {
+      "name": "Steffi LaZerte",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-7690-8360",
+      "directory_id": "steffi-lazerte"
+    },
+    {
+      "name": "Government of Canada",
+      "roles": [
+        "cph",
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/BayesERtools.json
+++ b/data/packages/BayesERtools.json
@@ -1,0 +1,45 @@
+{
+  "name": "BayesERtools",
+  "title": "Bayesian Exposure-Response Analysis Tools",
+  "description": "Suite of tools that facilitate exposure-response analysis using Bayesian methods. The package provides a streamlined workflow for fitting types of models that are commonly used in exposure-response analysis - linear and Emax for continuous endpoints, logistic linear and logistic Emax for binary endpoints, as well as performing simulation and visualization. Learn more about the workflow at <https://genentech.github.io/BayesERbook/>.",
+  "repo_url": null,
+  "pkdown_url": "https://genentech.github.io/BayesERtools/",
+  "bug_reports_url": null,
+  "logo_url": "https://genentech.github.io/BayesERtools/logo.png",
+  "last_updated": "2026-04-23",
+  "authors": [
+    {
+      "name": "Kenta Yoshida",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0003-4967-3831",
+      "email": "yoshida.kenta.6@gmail.com"
+    },
+    {
+      "name": "François Mercier",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-5685-1408"
+    },
+    {
+      "name": "Danielle Navarro",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-7648-6578",
+      "directory_id": "danielle-navarro"
+    },
+    {
+      "name": "Genentech"
+    },
+    {
+      "name": "Inc.",
+      "roles": [
+        "cph"
+      ]
+    }
+  ]
+}

--- a/data/packages/BradleyTerryScalable.json
+++ b/data/packages/BradleyTerryScalable.json
@@ -1,0 +1,27 @@
+{
+  "name": "BradleyTerryScalable",
+  "title": "Fits the Bradley-Terry Model to Potentially Large and Sparse\nNetworks of Comparison Data",
+  "description": "Facilities are provided for fitting the simple, unstructured Bradley-Terry model to networks of binary comparisons. The implemented methods are designed to scale well to large, potentially sparse, networks. A fairly high degree of scalability is achieved through the use of EM and MM algorithms, which are relatively undemanding in terms of memory usage (relative to some other commonly used methods such as iterative weighted least squares, for example). Both maximum likelihood and Bayesian MAP estimation methods are implemented. The package provides various standard methods for a newly defined 'btfit' model class, such as the extraction and summarisation of model parameters and the simulation of new datasets from a fitted model. Tools are also provided for reshaping data into the newly defined \"btdata\" class, and for analysing the comparison network, prior to fitting the Bradley-Terry model. This package complements, rather than replaces, the existing 'BradleyTerry2' package. (BradleyTerry2 has rather different aims, which are mainly the specification and fitting of \"structured\" Bradley-Terry models in which the strength parameters depend on covariates.)",
+  "repo_url": "https://github.com/EllaKaye/BradleyTerryScalable",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/EllaKaye/BradleyTerryScalable/issues",
+  "logo_url": null,
+  "last_updated": "2022-05-29",
+  "authors": [
+    {
+      "name": "Ella Kaye",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "directory_id": "ella-kaye",
+      "email": "E.Kaye.1@warwick.ac.uk"
+    },
+    {
+      "name": "David Firth",
+      "roles": [
+        "aut"
+      ]
+    }
+  ]
+}

--- a/data/packages/LITAP.json
+++ b/data/packages/LITAP.json
@@ -1,0 +1,33 @@
+{
+  "name": "LITAP",
+  "title": "Landscape Integrated Terrain Analysis Package",
+  "description": "Terrain analysis and landscape and hydrology models built on terrain attributes. A major component of LITAP is founded on R. A. (Bob) MacMillan's LandMapR suite of programs for flow topology and landform segmentation analyses with extended new parameters and methodologies, as well as with new calculations and uses of directional terrain attributes.",
+  "repo_url": "https://github.com/FRDC-SHL/LITAP",
+  "pkdown_url": null,
+  "bug_reports_url": null,
+  "logo_url": null,
+  "last_updated": "2024-10-02",
+  "authors": [
+    {
+      "name": "Steffi LaZerte",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "directory_id": "steffi-lazerte",
+      "email": "steffi@steffi.ca"
+    },
+    {
+      "name": "Sheng Li",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Agriculture and Agri-Food Canada",
+      "roles": [
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/MLDataR.json
+++ b/data/packages/MLDataR.json
@@ -1,0 +1,34 @@
+{
+  "name": "MLDataR",
+  "title": "Collection of Machine Learning Datasets for Supervised Machine\nLearning",
+  "description": "Contains a collection of datasets for working with machine learning tasks. It will contain datasets for supervised machine learning Jiang (2020)<doi:10.1016/j.beth.2020.05.002> and will include datasets for classification and regression. The aim of this package is to use data generated around health and other domains.",
+  "repo_url": "https://github.com/StatsGary/MLDataR",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/StatsGary/MLDataR/issues",
+  "logo_url": null,
+  "last_updated": "2022-10-03",
+  "authors": [
+    {
+      "name": "Gary Hutson",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0003-3534-6143",
+      "email": "hutsons-hacks@outlook.com"
+    },
+    {
+      "name": "Asif Laldin",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Isabella Velásquez",
+      "roles": [
+        "aut"
+      ],
+      "directory_id": "isabella-velasquez"
+    }
+  ]
+}

--- a/data/packages/MSUthemes.json
+++ b/data/packages/MSUthemes.json
@@ -1,0 +1,35 @@
+{
+  "name": "MSUthemes",
+  "title": "Michigan State University (MSU) Palettes and Themes",
+  "description": "Defines colour palettes and themes for Michigan State University (MSU) publications and presentations. Palettes and themes are supported in both base R and 'ggplot2' graphics, and are intended to provide consistency between those creating documents and presentations.",
+  "repo_url": "https://github.com/emilioxavier/MSUthemes",
+  "pkdown_url": "https://emilioxavier.github.io/MSUthemes/",
+  "bug_reports_url": "https://github.com/emilioxavier/MSUthemes/issues",
+  "logo_url": "https://emilioxavier.github.io/MSUthemes/logo.png",
+  "last_updated": "2025-10-17",
+  "authors": [
+    {
+      "name": "Emilio Xavier Esposito",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "orcid": "0000-0002-6193-0485",
+      "email": "emilio.esposito@gmail.com"
+    },
+    {
+      "name": "Nicola Rennie",
+      "roles": [
+        "aut"
+      ],
+      "directory_id": "nicola-rennie"
+    },
+    {
+      "name": "Michigan State University",
+      "roles": [
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/PrettyCols.json
+++ b/data/packages/PrettyCols.json
@@ -1,0 +1,21 @@
+{
+  "name": "PrettyCols",
+  "title": "Pretty Colour Palettes",
+  "description": "Defines aesthetically pleasing colour palettes.",
+  "repo_url": "https://github.com/nrennie/PrettyCols",
+  "pkdown_url": "https://nrennie.rbind.io/PrettyCols/",
+  "bug_reports_url": "https://github.com/nrennie/PrettyCols/issues",
+  "logo_url": "https://nrennie.rbind.io/PrettyCols/logo.png",
+  "last_updated": "2025-04-23",
+  "authors": [
+    {
+      "name": "Nicola Rennie",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "directory_id": "nicola-rennie",
+      "email": "nrennie35@gmail.com"
+    }
+  ]
+}

--- a/data/packages/RSSthemes.json
+++ b/data/packages/RSSthemes.json
@@ -1,0 +1,28 @@
+{
+  "name": "RSSthemes",
+  "title": "RSS Palettes and Themes",
+  "description": "Defines colour palettes and themes for Royal Statistical Society (RSS) publications, including Significance magazine. Palettes and themes are supported in both base R and 'ggplot2' graphics, and are intended to be used by authors submitting to RSS publications.",
+  "repo_url": "https://github.com/nrennie/RSSthemes",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/nrennie/RSSthemes/issues",
+  "logo_url": null,
+  "last_updated": "2024-03-02",
+  "authors": [
+    {
+      "name": "Nicola Rennie",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "directory_id": "nicola-rennie",
+      "email": "nrennie35@gmail.com"
+    },
+    {
+      "name": "Royal Statistical Society",
+      "roles": [
+        "fnd",
+        "cph"
+      ]
+    }
+  ]
+}

--- a/data/packages/SISINTAR.json
+++ b/data/packages/SISINTAR.json
@@ -1,0 +1,34 @@
+{
+  "name": "SISINTAR",
+  "title": "Lee y Manipula Datos de Suelo de SISINTA",
+  "description": "Permite descargar y manipular datos de perfiles de suelo disponibles en la plataforma SISINTA.",
+  "repo_url": "https://github.com/inta-suelos/SISINTAR",
+  "pkdown_url": null,
+  "bug_reports_url": null,
+  "logo_url": null,
+  "last_updated": "2023-05-30",
+  "authors": [
+    {
+      "name": "Yanina Bellini Saibene",
+      "roles": [
+        "cre",
+        "ctb"
+      ],
+      "directory_id": "yanina-bellini-saibene",
+      "email": "yabellini@gmail.com"
+    },
+    {
+      "name": "Elio Campitelli",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-7742-9230"
+    },
+    {
+      "name": "Paola Corrales",
+      "roles": [
+        "aut"
+      ]
+    }
+  ]
+}

--- a/data/packages/TextMiningTutorial.json
+++ b/data/packages/TextMiningTutorial.json
@@ -1,0 +1,21 @@
+{
+  "name": "TextMiningTutorial",
+  "title": "What the Package Does (One Line, Title Case)",
+  "description": "Tutorial de introducción a Text Mining",
+  "repo_url": "https://github.com/yabellini/TextMiningTutorial",
+  "pkdown_url": null,
+  "bug_reports_url": null,
+  "logo_url": null,
+  "last_updated": "2021-05-19",
+  "authors": [
+    {
+      "name": "Yanina Bellini Saibene",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "directory_id": "yanina-bellini-saibene",
+      "email": "yabellini@gmail.com"
+    }
+  ]
+}

--- a/data/packages/TutorialIterar.json
+++ b/data/packages/TutorialIterar.json
@@ -1,0 +1,21 @@
+{
+  "name": "TutorialIterar",
+  "title": "Tutoriales de learnr para aprender sobre iteracción en R",
+  "description": "este paquete contiene dos turoriales de learnr para aprender for loops y map.",
+  "repo_url": "https://github.com/yabellini/TutorialIterar",
+  "pkdown_url": null,
+  "bug_reports_url": null,
+  "logo_url": null,
+  "last_updated": "2021-04-25",
+  "authors": [
+    {
+      "name": "Yanina Bellini Saibene",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "directory_id": "yanina-bellini-saibene",
+      "email": "yabellini@gmail.com"
+    }
+  ]
+}

--- a/data/packages/TutorialgRaficosFN.json
+++ b/data/packages/TutorialgRaficosFN.json
@@ -1,0 +1,25 @@
+{
+  "name": "TutorialgRaficosFN",
+  "title": "Tutorial sobre Gráficos en R",
+  "description": "Tutorial para generar gráficos en R festejando a Florence Nightingale",
+  "repo_url": "https://github.com/yabellini/TutorialgRaficosFN",
+  "pkdown_url": null,
+  "bug_reports_url": null,
+  "logo_url": null,
+  "last_updated": "2021-05-11",
+  "authors": [
+    {
+      "name": "Yanina Bellini Saibene",
+      "directory_id": "yanina-bellini-saibene",
+      "email": "yabellini@gmail.com"
+    },
+    {
+      "name": "Yanina Bellini Saibene",
+      "roles": [
+        "cre"
+      ],
+      "directory_id": "yanina-bellini-saibene",
+      "email": "yabellini@gmail.com"
+    }
+  ]
+}

--- a/data/packages/airports.json
+++ b/data/packages/airports.json
@@ -1,0 +1,21 @@
+{
+  "name": "airports",
+  "title": "Data on Airports",
+  "description": "Geographic, use, and property related data on airports.",
+  "repo_url": "https://github.com/OpenIntroStat/airports",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/OpenIntroStat/airports/issues",
+  "logo_url": null,
+  "last_updated": "2020-06-29",
+  "authors": [
+    {
+      "name": "Mine Çetinkaya-Rundel",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-6452-2420",
+      "email": "cetinkaya.mine@gmail.com"
+    }
+  ]
+}

--- a/data/packages/aperol.json
+++ b/data/packages/aperol.json
@@ -1,0 +1,33 @@
+{
+  "name": "aperol",
+  "title": "Generates Tipsy or Drunk Praise",
+  "description": "This is a joke package, which generates praise using the praise package, then garbles it, as if being delivered by someone tipsy or drunk.",
+  "repo_url": "https://github.com/EllaKaye/aperol",
+  "pkdown_url": "https://ellakaye.github.io/aperol/",
+  "bug_reports_url": "https://github.com/EllaKaye/aperol/issues",
+  "logo_url": "https://ellakaye.github.io/aperol/logo.png",
+  "last_updated": "2025-02-27",
+  "authors": [
+    {
+      "name": "Ella Kaye",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "directory_id": "ella-kaye",
+      "email": "ella.kaye@gmail.com"
+    },
+    {
+      "name": "Kelly Bodwin",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Collin Schwantes",
+      "roles": [
+        "aut"
+      ]
+    }
+  ]
+}

--- a/data/packages/artpack.json
+++ b/data/packages/artpack.json
@@ -1,0 +1,23 @@
+{
+  "name": "artpack",
+  "title": "Creates Generative Art Data",
+  "description": "Create data that displays generative art when mapped into a 'ggplot2' plot. Functionality includes specialized data frame creation for geometric shapes, tools that define artistic color palettes, tools for geometrically transforming data, and other miscellaneous tools that are helpful when using 'ggplot2' for generative art.",
+  "repo_url": "https://github.com/Meghansaha/artpack",
+  "pkdown_url": "https://meghansaha.github.io/artpack/",
+  "bug_reports_url": "https://github.com/Meghansaha/artpack/issues",
+  "logo_url": "https://meghansaha.github.io/artpack/logo.png",
+  "last_updated": "2025-09-17",
+  "authors": [
+    {
+      "name": "Meghan Harris",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "orcid": "0000-0003-3922-8101",
+      "directory_id": "meghan-harris",
+      "email": "meghanha01@gmail.com"
+    }
+  ]
+}

--- a/data/packages/arttools.json
+++ b/data/packages/arttools.json
@@ -1,0 +1,22 @@
+{
+  "name": "arttools",
+  "title": "Tools For Generative Art Workflows",
+  "description": "A personal-use package for managing generative art workflows.",
+  "repo_url": "https://github.com/djnavarro/arttools",
+  "pkdown_url": "https://arttools.djnavarro.net/",
+  "bug_reports_url": "https://github.com/djnavarro/arttools/issues",
+  "logo_url": null,
+  "last_updated": "2026-03-21",
+  "authors": [
+    {
+      "name": "Danielle Navarro",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-7648-6578",
+      "directory_id": "danielle-navarro",
+      "email": "djnavarro@protonmail.com"
+    }
+  ]
+}

--- a/data/packages/asciify.json
+++ b/data/packages/asciify.json
@@ -1,0 +1,22 @@
+{
+  "name": "asciify",
+  "title": "Make ASCII Art From Images",
+  "description": "Takes an arbitrary image as input and constructs an text-based approximation to the image using the imager package.",
+  "repo_url": "https://github.com/djnavarro/asciify",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/djnavarro/asciify/issues",
+  "logo_url": null,
+  "last_updated": "2020-04-23",
+  "authors": [
+    {
+      "name": "Danielle Navarro",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-7648-6578",
+      "directory_id": "danielle-navarro",
+      "email": "d.navarro@unsw.edu.au"
+    }
+  ]
+}

--- a/data/packages/bakeoff.json
+++ b/data/packages/bakeoff.json
@@ -1,0 +1,36 @@
+{
+  "name": "bakeoff",
+  "title": "Data from \"The Great British Bake Off\"",
+  "description": "Data about the bakers, challenges, and ratings for \"The Great British Bake Off\", from Wikipedia <https://en.wikipedia.org/wiki/The_Great_British_Bake_Off>.",
+  "repo_url": "https://github.com/apreshill/bakeoff",
+  "pkdown_url": "https://bakeoff.netlify.app/",
+  "bug_reports_url": "https://github.com/apreshill/bakeoff/issues",
+  "logo_url": "https://bakeoff.netlify.app/logo.png",
+  "last_updated": "2022-11-02",
+  "authors": [
+    {
+      "name": "Alison Hill",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "orcid": "0000-0002-8082-1890",
+      "email": "apreshill@gmail.com"
+    },
+    {
+      "name": "Chester Ismay",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-2820-2547"
+    },
+    {
+      "name": "Richard Iannone",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-3925-190X"
+    }
+  ]
+}

--- a/data/packages/basepenguins.json
+++ b/data/packages/basepenguins.json
@@ -1,0 +1,38 @@
+{
+  "name": "basepenguins",
+  "title": "Convert Files that Use 'palmerpenguins' to Work with 'datasets'",
+  "description": "From 'R' 4.5.0, the 'datasets' package includes the penguins and penguins_raw data sets popularised in the 'palmerpenguins' package. 'basepenguins' takes files that use the 'palmerpenguins' package and converts them to work with the versions from 'datasets' ('R' >= 4.5.0). It does this by removing calls to library(palmerpenguins) and making the necessary changes to column names. Additionally, it provides helper functions to define new files paths for saving the output and a directory of example files to experiment with.",
+  "repo_url": "https://github.com/EllaKaye/basepenguins",
+  "pkdown_url": "https://ellakaye.github.io/basepenguins/",
+  "bug_reports_url": "https://github.com/EllaKaye/basepenguins/issues",
+  "logo_url": "https://ellakaye.github.io/basepenguins/logo.png",
+  "last_updated": "2025-04-10",
+  "authors": [
+    {
+      "name": "Ella Kaye",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "orcid": "0000-0002-7300-3718",
+      "directory_id": "ella-kaye",
+      "email": "ella.kaye@gmail.com"
+    },
+    {
+      "name": "Heather Turner",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-1256-3375",
+      "directory_id": "heather-turner"
+    },
+    {
+      "name": "Achim Zeileis",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0003-0918-3766"
+    }
+  ]
+}

--- a/data/packages/bayesrules.json
+++ b/data/packages/bayesrules.json
@@ -1,0 +1,35 @@
+{
+  "name": "bayesrules",
+  "title": "Datasets and Supplemental Functions from Bayes Rules! Book",
+  "description": "Provides datasets and functions used for analysis and visualizations in the Bayes Rules! book (<https://www.bayesrulesbook.com>). The package contains a set of functions that summarize and plot Bayesian models from some conjugate families and another set of functions for evaluation of some Bayesian models.",
+  "repo_url": "https://github.com/bayes-rules/bayesrules/",
+  "pkdown_url": "https://bayes-rules.github.io/bayesrules/docs/",
+  "bug_reports_url": "https://github.com/bayes-rules/bayesrules/issues",
+  "logo_url": null,
+  "last_updated": "2026-01-20",
+  "authors": [
+    {
+      "name": "Mine Dogucu",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-8007-934X",
+      "directory_id": "mine-dogucu",
+      "email": "mdogucu@gmail.com"
+    },
+    {
+      "name": "Alicia Johnson",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Miles Ott",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-4457-6565"
+    }
+  ]
+}

--- a/data/packages/bcaquiferdata.json
+++ b/data/packages/bcaquiferdata.json
@@ -1,0 +1,34 @@
+{
+  "name": "bcaquiferdata",
+  "title": "BC Aquifer data tools",
+  "description": "Set of tools for processing BC Aquifer lithology and yield data.",
+  "repo_url": "https://github.com/bcgov/bcaquiferdata",
+  "pkdown_url": "http://bcgov.github.io/bcaquiferdata/",
+  "bug_reports_url": null,
+  "logo_url": null,
+  "last_updated": "2026-02-06",
+  "authors": [
+    {
+      "name": "Steffi LaZerte",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-7690-8360",
+      "directory_id": "steffi-lazerte",
+      "email": "sel@steffilazerte.ca"
+    },
+    {
+      "name": "Christine Bieber",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Province of British Columbia",
+      "roles": [
+        "cph"
+      ]
+    }
+  ]
+}

--- a/data/packages/bcgwcat.json
+++ b/data/packages/bcgwcat.json
@@ -1,0 +1,34 @@
+{
+  "name": "bcgwcat",
+  "title": "BC Groundwater Chemistry Analysis Tool",
+  "description": "Set of tools for working with groundwater chemstry data from the BC Government Environmental Monitoring System (EMS). Download EMS data and a) export for use in AquaChem, b) view water quality summaries, c) create piper and stiff plots.",
+  "repo_url": "https://github.com/bcgov/bcgwcat/",
+  "pkdown_url": "https://bcgov.github.io/bcgwcat/",
+  "bug_reports_url": null,
+  "logo_url": null,
+  "last_updated": "2025-02-12",
+  "authors": [
+    {
+      "name": "Steffi LaZerte",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-7690-8360",
+      "directory_id": "steffi-lazerte",
+      "email": "sel@steffilazerte.ca"
+    },
+    {
+      "name": "Andarge Baye",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Province of British Columbia",
+      "roles": [
+        "cph"
+      ]
+    }
+  ]
+}

--- a/data/packages/bcgwlreports.json
+++ b/data/packages/bcgwlreports.json
@@ -1,0 +1,29 @@
+{
+  "name": "bcgwlreports",
+  "title": "Create BC Groundwater Level Reports",
+  "description": "Fetch data, calculate historical percentiles and create reports of BC groundwater levels for set dates.",
+  "repo_url": "https://github.com/bcgov/bcgwlreports",
+  "pkdown_url": null,
+  "bug_reports_url": null,
+  "logo_url": null,
+  "last_updated": "2024-08-07",
+  "authors": [
+    {
+      "name": "Steffi LaZerte",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-7690-8360",
+      "directory_id": "steffi-lazerte",
+      "email": "steffi@steffi.ca"
+    },
+    {
+      "name": "Jon Goetz",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-4993-1119"
+    }
+  ]
+}

--- a/data/packages/bs4cards.json
+++ b/data/packages/bs4cards.json
@@ -1,0 +1,22 @@
+{
+  "name": "bs4cards",
+  "title": "Generate Bootstrap Cards",
+  "description": "Allows the user to generate bootstrap cards within R markdown documents. Intended for use in conjunction with R markdown HTML outputs and other formats that support the bootstrap 4 library.",
+  "repo_url": "https://github.com/djnavarro/bs4cards",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/djnavarro/bs4cards/issues",
+  "logo_url": null,
+  "last_updated": "2021-11-30",
+  "authors": [
+    {
+      "name": "Danielle Navarro",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-7648-6578",
+      "directory_id": "danielle-navarro",
+      "email": "djnavarro@protonmail.com"
+    }
+  ]
+}

--- a/data/packages/bundle.json
+++ b/data/packages/bundle.json
@@ -1,0 +1,50 @@
+{
+  "name": "bundle",
+  "title": "Serialize Model Objects with a Consistent Interface",
+  "description": "Typically, models in 'R' exist in memory and can be saved via regular 'R' serialization. However, some models store information in locations that cannot be saved using 'R' serialization alone. The goal of 'bundle' is to provide a common interface to capture this information, situate it within a portable object, and restore it for use in new settings.",
+  "repo_url": "https://github.com/rstudio/bundle",
+  "pkdown_url": "https://rstudio.github.io/bundle/",
+  "bug_reports_url": "https://github.com/rstudio/bundle/issues",
+  "logo_url": null,
+  "last_updated": "2025-12-10",
+  "authors": [
+    {
+      "name": "Julia Silge",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-3671-836X",
+      "directory_id": "julia-silge",
+      "email": "julia.silge@posit.co"
+    },
+    {
+      "name": "Simon Couch",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Qiushi Yan",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Max Kuhn",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Posit Software"
+    },
+    {
+      "name": "PBC",
+      "roles": [
+        "cph",
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/butcher.json
+++ b/data/packages/butcher.json
@@ -1,0 +1,58 @@
+{
+  "name": "butcher",
+  "title": "Model Butcher",
+  "description": "Provides a set of S3 generics to axe components of fitted model objects and help reduce the size of model objects saved to disk.",
+  "repo_url": "https://github.com/tidymodels/butcher",
+  "pkdown_url": "https://butcher.tidymodels.org/",
+  "bug_reports_url": "https://github.com/tidymodels/butcher/issues",
+  "logo_url": "https://butcher.tidymodels.org/logo.png",
+  "last_updated": "2025-12-09",
+  "authors": [
+    {
+      "name": "Joyce Cahoon",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-7217-4702"
+    },
+    {
+      "name": "Davis Vaughan",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Max Kuhn",
+      "roles": [
+        "cre",
+        "aut"
+      ],
+      "orcid": "0000-0003-2402-136X",
+      "email": "max@posit.co"
+    },
+    {
+      "name": "Alex Hayes",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Julia Silge",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-3671-836X",
+      "directory_id": "julia-silge"
+    },
+    {
+      "name": "Posit Software"
+    },
+    {
+      "name": "PBC",
+      "roles": [
+        "cph",
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/capesData.json
+++ b/data/packages/capesData.json
@@ -1,0 +1,42 @@
+{
+  "name": "capesData",
+  "title": "Data on Scholarships in CAPES International Mobility Programs",
+  "description": "Information on activities to promote scholarships in Brazil and abroad for international mobility programs, recorded in Capes' computerized payment systems. The CAPES database refers to international mobility programs for the period from 2010 to 2019 <https://dadosabertos.capes.gov.br/dataset/>.",
+  "repo_url": null,
+  "pkdown_url": null,
+  "bug_reports_url": null,
+  "logo_url": null,
+  "last_updated": "2024-08-28",
+  "authors": [
+    {
+      "name": "Leonardo Biazoli",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0003-4069-111X",
+      "email": "leonardobiazoli19@gmail.com"
+    },
+    {
+      "name": "Mine Çetinkaya-Rundel",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-6452-2420"
+    },
+    {
+      "name": "Eric Fernandes de Mello Araujo",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-4263-9075"
+    },
+    {
+      "name": "Izabela R. Cardoso de Oliveira",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-3254-2827"
+    }
+  ]
+}

--- a/data/packages/cereal.json
+++ b/data/packages/cereal.json
@@ -1,0 +1,38 @@
+{
+  "name": "cereal",
+  "title": "Serialize 'vctrs' Objects to 'JSON'",
+  "description": "The 'vctrs' package provides a concept of vector prototype that can be especially useful when deploying models and code. Serialize these object prototypes to 'JSON' so they can be used to check and coerce data in production systems, and deserialize 'JSON' back to the correct object prototypes.",
+  "repo_url": "https://github.com/r-lib/cereal/",
+  "pkdown_url": "https://r-lib.github.io/cereal/",
+  "bug_reports_url": "https://github.com/r-lib/cereal/issues",
+  "logo_url": null,
+  "last_updated": "2023-06-09",
+  "authors": [
+    {
+      "name": "Julia Silge",
+      "roles": [
+        "cre",
+        "aut"
+      ],
+      "orcid": "0000-0002-3671-836X",
+      "directory_id": "julia-silge",
+      "email": "julia.silge@posit.co"
+    },
+    {
+      "name": "Davis Vaughan",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Posit Software"
+    },
+    {
+      "name": "PBC",
+      "roles": [
+        "cph",
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/cherryblossom.json
+++ b/data/packages/cherryblossom.json
@@ -1,0 +1,21 @@
+{
+  "name": "cherryblossom",
+  "title": "Cherry Blossom Run Race Results",
+  "description": "Race results of the Cherry Blossom Run, which is an annual road race that takes place in Washington, DC.",
+  "repo_url": "https://github.com/OpenIntroStat/cherryblossom",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/OpenIntroStat/cherryblossom/issues",
+  "logo_url": null,
+  "last_updated": "2020-06-25",
+  "authors": [
+    {
+      "name": "Mine Çetinkaya-Rundel",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-6452-2420",
+      "email": "cetinkaya.mine@gmail.com"
+    }
+  ]
+}

--- a/data/packages/codemeta.json
+++ b/data/packages/codemeta.json
@@ -1,0 +1,92 @@
+{
+  "name": "codemeta",
+  "title": "A Smaller 'codemetar' Package",
+  "description": "The 'Codemeta' Project defines a 'JSON-LD' format for describing software metadata, as detailed at <https://codemeta.github.io>. This package provides core utilities to generate this metadata with a minimum of dependencies.",
+  "repo_url": "https://github.com/cboettig/codemeta",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/cboettig/codemeta/issues",
+  "logo_url": null,
+  "last_updated": "2021-12-22",
+  "authors": [
+    {
+      "name": "Carl Boettiger",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "orcid": "0000-0002-1642-628X",
+      "email": "cboettig@gmail.com"
+    },
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "ctb",
+        "aut"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon"
+    },
+    {
+      "name": "Katrin Leinweber",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-5135-5758"
+    },
+    {
+      "name": "Noam Ross",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-2136-0000"
+    },
+    {
+      "name": "Arfon Smith",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Jeroen Ooms",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-4035-0289"
+    },
+    {
+      "name": "Sebastian Meyer",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-1791-9449"
+    },
+    {
+      "name": "Michael Rustler",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0003-0647-7726"
+    },
+    {
+      "name": "Hauke Sonnenberg",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-9134-2871"
+    },
+    {
+      "name": "Sebastian Kreutzer",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-0734-2199"
+    },
+    {
+      "name": "rOpenSci",
+      "roles": [
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/codemetar.json
+++ b/data/packages/codemetar.json
@@ -1,0 +1,114 @@
+{
+  "name": "codemetar",
+  "title": "Generate 'CodeMeta' Metadata for R Packages",
+  "description": "The 'Codemeta' Project defines a 'JSON-LD' format for describing software metadata, as detailed at <https://codemeta.github.io>. This package provides utilities to generate, parse, and modify 'codemeta.json' files automatically for R packages, as well as tools and examples for working with 'codemeta.json' 'JSON-LD' more generally.",
+  "repo_url": "https://github.com/ropensci/codemetar",
+  "pkdown_url": "https://docs.ropensci.org/codemetar/",
+  "bug_reports_url": "https://github.com/ropensci/codemetar/issues",
+  "logo_url": "https://docs.ropensci.org/codemetar/logo.png",
+  "last_updated": "2026-02-11",
+  "authors": [
+    {
+      "name": "Carl Boettiger",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "orcid": "0000-0002-1642-628X",
+      "email": "cboettig@gmail.com"
+    },
+    {
+      "name": "Anna Krystalli",
+      "roles": [
+        "rev",
+        "ctb"
+      ],
+      "orcid": "0000-0002-2378-4915"
+    },
+    {
+      "name": "Toph Allen",
+      "roles": [
+        "rev"
+      ],
+      "orcid": "0000-0003-4580-091X"
+    },
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "ctb",
+        "aut"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon"
+    },
+    {
+      "name": "rOpenSci",
+      "roles": [
+        "fnd"
+      ]
+    },
+    {
+      "name": "Katrin Leinweber",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-5135-5758"
+    },
+    {
+      "name": "Noam Ross",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-2136-0000"
+    },
+    {
+      "name": "Arfon Smith",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Jeroen Ooms",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-4035-0289"
+    },
+    {
+      "name": "Sebastian Meyer",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-1791-9449"
+    },
+    {
+      "name": "Michael Rustler",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0003-0647-7726"
+    },
+    {
+      "name": "Hauke Sonnenberg",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-9134-2871"
+    },
+    {
+      "name": "Sebastian Kreutzer",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-0734-2199"
+    },
+    {
+      "name": "Thierry Onkelinx",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-8804-4216"
+    }
+  ]
+}

--- a/data/packages/colorhex.json
+++ b/data/packages/colorhex.json
@@ -1,0 +1,30 @@
+{
+  "name": "colorhex",
+  "title": "Colors and Palettes from Color-Hex",
+  "description": "The website <https://www.color-hex.com> is a great resource of hex colour codes and palettes. This package allows you to retrieve palettes and colour information from the website directly from R. There are also custom scale-functions for 'ggplot2'.",
+  "repo_url": "https://github.com/drmowinckels/colorhex",
+  "pkdown_url": "https://drmowinckels.github.io/colorhex/",
+  "bug_reports_url": "https://github.com/drmowinckels/colorhex/issues",
+  "logo_url": null,
+  "last_updated": "2023-09-15",
+  "authors": [
+    {
+      "name": "Athanasia Mo Mowinckel",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-5756-0223",
+      "directory_id": "athanasia-mo-mowinckel",
+      "email": "a.m.mowinckel@psykologi.uio.no"
+    },
+    {
+      "name": "Julia Romanowska",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-6733-1953",
+      "directory_id": "julia-romanowska"
+    }
+  ]
+}

--- a/data/packages/cransays.json
+++ b/data/packages/cransays.json
@@ -1,0 +1,71 @@
+{
+  "name": "cransays",
+  "title": "Creates an Overview of CRAN Incoming Submissions",
+  "description": "It scrapes the CRAN incoming FTP folder to find where each submission is.",
+  "repo_url": "https://github.com/r-hub/cransays",
+  "pkdown_url": "https://r-hub.github.io/cransays/",
+  "bug_reports_url": "https://github.com/r-hub/cransays/issues",
+  "logo_url": null,
+  "last_updated": "2025-12-26",
+  "authors": [
+    {
+      "name": "Hugo Gruson",
+      "roles": [
+        "cre",
+        "aut"
+      ],
+      "orcid": "0000-0002-4094-1476",
+      "email": "hugo.gruson+R@normalesup.org"
+    },
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "aut",
+        "ccp"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon"
+    },
+    {
+      "name": "Locke Data",
+      "roles": [
+        "fnd"
+      ]
+    },
+    {
+      "name": "Stephanie Locke",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-2387-3723"
+    },
+    {
+      "name": "Mitchell O'Hara-Wild",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-6729-7695"
+    },
+    {
+      "name": "Lluís Revilla Sancho",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-9747-2570"
+    },
+    {
+      "name": "Jim Hester",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-2739-7082"
+    },
+    {
+      "name": "Hadley Wickham",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0003-4757-117X"
+    }
+  ]
+}

--- a/data/packages/dados.json
+++ b/data/packages/dados.json
@@ -1,0 +1,88 @@
+{
+  "name": "dados",
+  "title": "Translate Datasets to Portuguese",
+  "description": "Este pacote traduz os seguintes conjuntos de dados: 'airlines', 'airports', 'ames_raw', 'AwardsManagers', 'babynames', 'Batting', 'diamonds', 'faithful', 'fueleconomy', 'Fielding', 'flights', 'gapminder', 'gss_cat', 'iris', 'Managers', 'mpg', 'mtcars', 'atmos', 'penguins', 'People, 'Pitching', 'pixarfilms','planes', 'presidential', 'table1', 'table2', 'table3', 'table4a', 'table4b', 'table5', 'vehicles', 'weather', 'who'. English: It provides a Portuguese translated version of the datasets listed above.",
+  "repo_url": "https://github.com/cienciadedatos/dados",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/cienciadedatos/dados/issues",
+  "logo_url": null,
+  "last_updated": "2022-02-24",
+  "authors": [
+    {
+      "name": "Riva Quiroga",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-1147-4135",
+      "directory_id": "riva-quiroga",
+      "email": "riva.quiroga@uc.cl"
+    },
+    {
+      "name": "Sara Mortara",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-6221-7537"
+    },
+    {
+      "name": "Beatriz Milz",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-3064-4486",
+      "directory_id": "beatriz-milz"
+    },
+    {
+      "name": "Andrea Sánchez-Tapia",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-3521-4338",
+      "directory_id": "andrea-sancheztapia"
+    },
+    {
+      "name": "Alejandra Andrea Tapia Silva",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-0762-7618"
+    },
+    {
+      "name": "Beatriz Maurer Costa",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Jean Prado",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-7928-774X"
+    },
+    {
+      "name": "Renata Hirota",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-3589-3246",
+      "directory_id": "renata-hirota"
+    },
+    {
+      "name": "William Amorim",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-0543-3473"
+    },
+    {
+      "name": "Emmanuelle Rodrigues Nunes",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-5994-352X",
+      "directory_id": "emmanuelle-rodrigues-nunes"
+    }
+  ]
+}

--- a/data/packages/dataspice.json
+++ b/data/packages/dataspice.json
@@ -1,0 +1,77 @@
+{
+  "name": "dataspice",
+  "title": "Create Lightweight Schema.org Descriptions of Data",
+  "description": "The goal of 'dataspice' is to make it easier for researchers to create basic, lightweight, and concise metadata files for their datasets. These basic files can then be used to make useful information available during analysis, create a helpful dataset \"README\" webpage, and produce more complex metadata formats to aid dataset discovery. Metadata fields are based on the 'Schema.org' and 'Ecological Metadata Language' standards.",
+  "repo_url": "https://github.com/ropensci/dataspice",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/ropensci/dataspice/issues",
+  "logo_url": null,
+  "last_updated": "2025-09-23",
+  "authors": [
+    {
+      "name": "Carl Boettiger",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Scott Chamberlain",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Auriel Fournier",
+      "roles": [
+        "aut"
+      ],
+      "directory_id": "auriel-fournier"
+    },
+    {
+      "name": "Kelly Hondula",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Anna Krystalli",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Bryce Mecum",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "email": "brycemecum@gmail.com"
+    },
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "aut"
+      ],
+      "directory_id": "maelle-salmon"
+    },
+    {
+      "name": "Kate Webbink",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Kara Woo",
+      "roles": [
+        "aut"
+      ],
+      "directory_id": "kara-woo"
+    },
+    {
+      "name": "Irene Steves",
+      "roles": [
+        "ctb"
+      ]
+    }
+  ]
+}

--- a/data/packages/emodnet.wfs.json
+++ b/data/packages/emodnet.wfs.json
@@ -1,0 +1,82 @@
+{
+  "name": "emodnet.wfs",
+  "title": "Access 'EMODnet' Web Feature Service Data",
+  "description": "Access and interrogate 'EMODnet' (European Marine Observation and Data Network) Web Feature Service data <https://emodnet.ec.europa.eu/en/emodnet-web-service-documentation#data-download-services>. This includes listing existing data sources, and getting data from each of them.",
+  "repo_url": "https://github.com/EMODnet/emodnet.wfs",
+  "pkdown_url": "https://docs.ropensci.org/emodnet.wfs/",
+  "bug_reports_url": "https://github.com/EMODnet/emodnet.wfs/issues",
+  "logo_url": "https://docs.ropensci.org/emodnet.wfs/logo.svg",
+  "last_updated": "2026-03-26",
+  "authors": [
+    {
+      "name": "Joana Beja",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-5196-8447",
+      "email": "joana.beja@vliz.be"
+    },
+    {
+      "name": "Anna Krystalli",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-2378-4915"
+    },
+    {
+      "name": "Salvador Fernández-Bejarano",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-0535-7677"
+    },
+    {
+      "name": "Thomas J Webb",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "European Marine Observation Data Network",
+      "roles": [
+        "cph"
+      ]
+    },
+    {
+      "name": "VLIZ",
+      "roles": [
+        "fnd"
+      ]
+    },
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon"
+    },
+    {
+      "name": "Alec L. Robitaille",
+      "roles": [
+        "rev"
+      ],
+      "orcid": "0000-0002-4706-1762"
+    },
+    {
+      "name": "Liz Hare",
+      "roles": [
+        "rev"
+      ],
+      "orcid": "0000-0002-3978-2543"
+    },
+    {
+      "name": "François Michonneau",
+      "roles": [
+        "rev"
+      ],
+      "orcid": "0000-0002-9092-966X"
+    }
+  ]
+}

--- a/data/packages/flametree.json
+++ b/data/packages/flametree.json
@@ -1,0 +1,22 @@
+{
+  "name": "flametree",
+  "title": "Generate Random Tree-Like Images",
+  "description": "A generative art system for producing tree-like images using an L-system to create the structures. The package includes tools for generating the data structures and visualise them in a variety of styles.",
+  "repo_url": "https://github.com/djnavarro/flametree",
+  "pkdown_url": "https://flametree.djnavarro.net/",
+  "bug_reports_url": "https://github.com/djnavarro/flametree/issues",
+  "logo_url": null,
+  "last_updated": "2026-03-21",
+  "authors": [
+    {
+      "name": "Danielle Navarro",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-7648-6578",
+      "directory_id": "danielle-navarro",
+      "email": "djnavarro@protonmail.com"
+    }
+  ]
+}

--- a/data/packages/ggPMX.json
+++ b/data/packages/ggPMX.json
@@ -1,0 +1,132 @@
+{
+  "name": "ggPMX",
+  "title": "'ggplot2' Based Tool to Facilitate Diagnostic Plots for NLME\nModels",
+  "description": "At Novartis, we aimed at standardizing the set of diagnostic plots used for modeling activities in order to reduce the overall effort required for generating such plots. For this, we developed a guidance that proposes an adequate set of diagnostics and a toolbox, called 'ggPMX' to execute them. 'ggPMX' is a toolbox that can generate all diagnostic plots at a quality sufficient for publication and submissions using few lines of code. This package focuses on plots recommended by ISoP <doi:10.1002/psp4.12161>. While not required, you can get/install the 'R' 'lixoftConnectors' package in the 'Monolix' installation, as described at the following url <https://monolixsuite.slp-software.com/r-functions/2024R1/installation-and-initialization>. When 'lixoftConnectors' is available, 'R' can use 'Monolix' directly to create the required Chart Data instead of exporting it from the 'Monolix' gui.",
+  "repo_url": "https://github.com/ggPMXdevelopment/ggPMX",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/ggPMXdevelopment/ggPMX/issues",
+  "logo_url": null,
+  "last_updated": "2025-09-05",
+  "authors": [
+    {
+      "name": "Amine Gassem",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Bruno Bieth",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Irina Baltcheva",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Thomas Dumortier",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Christian Bartels",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Souvik Bhattacharya",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Inga Ludwig",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Ines Paule",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Didier Renard",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Matthew Fidler",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-8538-6691"
+    },
+    {
+      "name": "Seid Hamzic",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Benjamin Guiastrennec",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Kyle T Baron",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-7252-5656"
+    },
+    {
+      "name": "Qing Xi Ooi",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Aleksandr Pogodaev",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-1371-207X",
+      "email": "alex.pogodaev@novartis.com"
+    },
+    {
+      "name": "Danielle Navarro",
+      "roles": [
+        "aut"
+      ],
+      "directory_id": "danielle-navarro"
+    },
+    {
+      "name": "Ibtissem Rebai",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Mahmoud Ali",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Novartis Pharma AG",
+      "roles": [
+        "cph"
+      ]
+    }
+  ]
+}

--- a/data/packages/ggauto.json
+++ b/data/packages/ggauto.json
@@ -1,0 +1,22 @@
+{
+  "name": "ggauto",
+  "title": "Automatically Create and Style 'ggplot2' Charts",
+  "description": "Automatically choose an appropriate chart type based on the types and values in the data. Apply more accessible default styling and colours to 'ggplot2' charts.",
+  "repo_url": "https://github.com/nrennie/ggauto",
+  "pkdown_url": "https://nrennie.rbind.io/ggauto/",
+  "bug_reports_url": "https://github.com/nrennie/ggauto/issues",
+  "logo_url": "https://nrennie.rbind.io/ggauto/logo.png",
+  "last_updated": "2026-04-24",
+  "authors": [
+    {
+      "name": "Nicola Rennie",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "directory_id": "nicola-rennie",
+      "email": "nrennie.research@gmail.com"
+    }
+  ]
+}

--- a/data/packages/ggflowchart.json
+++ b/data/packages/ggflowchart.json
@@ -1,0 +1,22 @@
+{
+  "name": "ggflowchart",
+  "title": "Flowcharts with 'ggplot2'",
+  "description": "Flowcharts can be a useful way to visualise complex processes. This package uses the layered grammar of graphics of 'ggplot2' to create simple flowcharts.",
+  "repo_url": "https://github.com/nrennie/ggflowchart",
+  "pkdown_url": "https://nrennie.github.io/ggflowchart/",
+  "bug_reports_url": "https://github.com/nrennie/ggflowchart/issues",
+  "logo_url": "https://nrennie.github.io/ggflowchart/logo.png",
+  "last_updated": "2023-12-20",
+  "authors": [
+    {
+      "name": "Nicola Rennie",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "directory_id": "nicola-rennie",
+      "email": "nrennie35@gmail.com"
+    }
+  ]
+}

--- a/data/packages/ghclass.json
+++ b/data/packages/ghclass.json
@@ -1,0 +1,32 @@
+{
+  "name": "ghclass",
+  "title": "Tools for Managing Classes on GitHub",
+  "description": "Interface for the GitHub API that enables efficient management of courses on GitHub. It has a functionality for managing organizations, teams, repositories, and users on GitHub and helps automate most of the tedious and repetitive tasks around creating and distributing assignments.",
+  "repo_url": "https://github.com/rundel/ghclass",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/rundel/ghclass/issues",
+  "logo_url": null,
+  "last_updated": "2025-05-06",
+  "authors": [
+    {
+      "name": "Colin Rundel",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "email": "rundel@gmail.com"
+    },
+    {
+      "name": "Mine Cetinkaya-Rundel",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Therese Anders",
+      "roles": [
+        "ctb"
+      ]
+    }
+  ]
+}

--- a/data/packages/glitter.json
+++ b/data/packages/glitter.json
@@ -1,0 +1,30 @@
+{
+  "name": "glitter",
+  "title": "glitter makes SPARQL",
+  "description": "This package aims at writing and sending SPARQL queries. It makes the exploration and use of Linked Open Data (Wikidata in particular) easier for those who do not know SPARQL.",
+  "repo_url": "https://github.com/lvaudor/glitter",
+  "pkdown_url": "https://lvaudor.github.io/glitter/",
+  "bug_reports_url": "https://github.com/lvaudor/glitter/issues",
+  "logo_url": "https://lvaudor.github.io/glitter/logo.png",
+  "last_updated": "2023-12-21",
+  "authors": [
+    {
+      "name": "Lise Vaudor",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0003-1844-6425",
+      "directory_id": "lise-vaudor",
+      "email": "lise.vaudor@ens-lyon.fr"
+    },
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon"
+    }
+  ]
+}

--- a/data/packages/gtreg.json
+++ b/data/packages/gtreg.json
@@ -1,0 +1,30 @@
+{
+  "name": "gtreg",
+  "title": "Regulatory Tables for Clinical Research",
+  "description": "Creates tables suitable for regulatory agency submission by leveraging the 'gtsummary' package as the back end. Tables can be exported to HTML, Word, PDF and more. Highly customized outputs are available by utilizing existing styling functions from 'gtsummary' as well as custom options designed for regulatory tables.",
+  "repo_url": "https://github.com/shannonpileggi/gtreg",
+  "pkdown_url": "https://shannonpileggi.github.io/gtreg/",
+  "bug_reports_url": "https://github.com/shannonpileggi/gtreg/issues",
+  "logo_url": "https://shannonpileggi.github.io/gtreg/logo.png",
+  "last_updated": "2025-11-25",
+  "authors": [
+    {
+      "name": "Shannon Pileggi",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "orcid": "0000-0002-7732-4164",
+      "directory_id": "shannon-pileggi",
+      "email": "shannon.pileggi@gmail.com"
+    },
+    {
+      "name": "Daniel D. Sjoberg",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-0862-2018"
+    }
+  ]
+}

--- a/data/packages/hellodatascience.json
+++ b/data/packages/hellodatascience.json
@@ -1,0 +1,35 @@
+{
+  "name": "hellodatascience",
+  "title": "Datasets from the Hello Data Science Book",
+  "description": "Provides datasets used for analysis and visualizations in the open-access Hello Data Science book.",
+  "repo_url": "https://github.com/hellodata-science/hellodatascience",
+  "pkdown_url": "https://hellodata-science.github.io/hellodatascience/",
+  "bug_reports_url": "https://github.com/hellodata-science/hellodatascience/issues",
+  "logo_url": "https://hellodata-science.github.io/hellodatascience/logo.png",
+  "last_updated": "2026-01-19",
+  "authors": [
+    {
+      "name": "Mine Dogucu",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-8007-934X",
+      "directory_id": "mine-dogucu",
+      "email": "mdogucu@gmail.com"
+    },
+    {
+      "name": "Catalina Medina",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-2847-8180"
+    },
+    {
+      "name": "Alma Castro",
+      "roles": [
+        "aut"
+      ]
+    }
+  ]
+}

--- a/data/packages/hexify.json
+++ b/data/packages/hexify.json
@@ -1,0 +1,22 @@
+{
+  "name": "hexify",
+  "title": "Create Hex Stickers",
+  "description": "Allows the user to create hex stickers from images.",
+  "repo_url": "https://github.com/djnavarro/hexify",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/djnavarro/hexify/issues",
+  "logo_url": null,
+  "last_updated": "2022-02-02",
+  "authors": [
+    {
+      "name": "Danielle Navarro",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-7648-6578",
+      "directory_id": "danielle-navarro",
+      "email": "djnavarro@protonmail.com"
+    }
+  ]
+}

--- a/data/packages/hmsidwR.json
+++ b/data/packages/hmsidwR.json
@@ -1,0 +1,22 @@
+{
+  "name": "hmsidwR",
+  "title": "Health Metrics and the Spread of Infectious Diseases",
+  "description": "A collection of datasets and supporting functions accompanying Health Metrics and the Spread of Infectious Diseases by Federica Gazzelloni (2024). This package provides data for health metrics calculations, including Disability-Adjusted Life Years (DALYs), Years of Life Lost (YLLs), and Years Lived with Disability (YLDs), as well as additional tools for analyzing and visualizing health data. Federica Gazzelloni (2024) <doi:10.5281/zenodo.10818338>.",
+  "repo_url": "https://github.com/Fgazzelloni/hmsidwR",
+  "pkdown_url": "https://fgazzelloni.github.io/hmsidwR/",
+  "bug_reports_url": "https://github.com/Fgazzelloni/hmsidwR/issues",
+  "logo_url": "https://fgazzelloni.github.io/hmsidwR/logo.png",
+  "last_updated": "2025-05-16",
+  "authors": [
+    {
+      "name": "Federica Gazzelloni",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-4285-611X",
+      "directory_id": "federica-gazzelloni",
+      "email": "fede.gazzelloni@gmail.com"
+    }
+  ]
+}

--- a/data/packages/igraph.json
+++ b/data/packages/igraph.json
@@ -1,0 +1,95 @@
+{
+  "name": "igraph",
+  "title": "Network Analysis and Visualization",
+  "description": "Routines for simple graphs and network analysis. It can handle large graphs very well and provides functions for generating random and regular graphs, graph visualization, centrality methods and much more.",
+  "repo_url": "https://github.com/igraph/rigraph",
+  "pkdown_url": "https://r.igraph.org/",
+  "bug_reports_url": "https://github.com/igraph/rigraph/issues",
+  "logo_url": "https://r.igraph.org/logo.png",
+  "last_updated": "2026-05-04",
+  "authors": [
+    {
+      "name": "Gábor Csárdi",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-7098-9676"
+    },
+    {
+      "name": "Tamás Nepusz",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-1451-338X"
+    },
+    {
+      "name": "Vincent Traag",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-3170-3879"
+    },
+    {
+      "name": "Szabolcs Horvát",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-3100-523X"
+    },
+    {
+      "name": "Fabio Zanini",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-7097-8539"
+    },
+    {
+      "name": "Daniel Noom",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Kirill Müller",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-1416-3412",
+      "email": "kirill@cynkra.com"
+    },
+    {
+      "name": "Michael Antonov",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Chan Zuckerberg Initiative",
+      "roles": [
+        "fnd"
+      ]
+    },
+    {
+      "name": "David Schoch",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-2952-4812"
+    },
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon"
+    },
+    {
+      "name": "R Consortium",
+      "roles": [
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/infer.json
+++ b/data/packages/infer.json
@@ -1,0 +1,106 @@
+{
+  "name": "infer",
+  "title": "Tidy Statistical Inference",
+  "description": "The objective of this package is to perform inference using an expressive statistical grammar that coheres with the tidy design framework.",
+  "repo_url": "https://github.com/tidymodels/infer",
+  "pkdown_url": "https://infer.tidymodels.org/",
+  "bug_reports_url": "https://github.com/tidymodels/infer/issues",
+  "logo_url": "https://infer.tidymodels.org/logo.png",
+  "last_updated": "2025-12-18",
+  "authors": [
+    {
+      "name": "Andrew Bray",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Chester Ismay",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-2820-2547"
+    },
+    {
+      "name": "Evgeni Chasnovski",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-1617-4019"
+    },
+    {
+      "name": "Simon Couch",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-5676-5107",
+      "email": "simon.couch@posit.co"
+    },
+    {
+      "name": "Ben Baumer",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-3279-0516"
+    },
+    {
+      "name": "Mine Cetinkaya-Rundel",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-6452-2420"
+    },
+    {
+      "name": "Ted Laderas",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-6207-7068"
+    },
+    {
+      "name": "Nick Solomon",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Johanna Hardin",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Albert Y. Kim",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-7824-306X"
+    },
+    {
+      "name": "Neal Fultz",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Doug Friedman",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Richie Cotton",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0003-2504-802X"
+    },
+    {
+      "name": "Brian Fannin",
+      "roles": [
+        "ctb"
+      ]
+    }
+  ]
+}

--- a/data/packages/janeaustenr.json
+++ b/data/packages/janeaustenr.json
@@ -1,0 +1,22 @@
+{
+  "name": "janeaustenr",
+  "title": "Jane Austen's Complete Novels",
+  "description": "Full texts for Jane Austen's 6 completed novels, ready for text analysis. These novels are \"Sense and Sensibility\", \"Pride and Prejudice\", \"Mansfield Park\", \"Emma\", \"Northanger Abbey\", and \"Persuasion\".",
+  "repo_url": "https://github.com/juliasilge/janeaustenr",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/juliasilge/janeaustenr/issues",
+  "logo_url": null,
+  "last_updated": "2022-08-26",
+  "authors": [
+    {
+      "name": "Julia Silge",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-3671-836X",
+      "directory_id": "julia-silge",
+      "email": "julia.silge@gmail.com"
+    }
+  ]
+}

--- a/data/packages/jasmines.json
+++ b/data/packages/jasmines.json
@@ -1,0 +1,22 @@
+{
+  "name": "jasmines",
+  "title": "Generative Art",
+  "description": "It doesn't do much, really.",
+  "repo_url": "https://github.com/djnavarro/jasmines",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/djnavarro/jasmines/issues",
+  "logo_url": null,
+  "last_updated": "2021-04-07",
+  "authors": [
+    {
+      "name": "Danielle Navarro",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-7648-6578",
+      "directory_id": "danielle-navarro",
+      "email": "d.navarro@unsw.edu.au"
+    }
+  ]
+}

--- a/data/packages/jaysire.json
+++ b/data/packages/jaysire.json
@@ -1,0 +1,25 @@
+{
+  "name": "jaysire",
+  "title": "Build jsPsych Experiments in R",
+  "description": "The jaysire package allows the user to build browser based behavioral experiments within R by providing an interface to the jsPsych javascript library.",
+  "repo_url": "https://github.com/djnavarro/jaysire",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/djnavarro/jaysire/issues",
+  "logo_url": null,
+  "last_updated": "2021-04-07",
+  "authors": [
+    {
+      "name": "Danielle Navarro",
+      "directory_id": "danielle-navarro",
+      "email": "d.navarro@unsw.edu.au"
+    },
+    {
+      "name": "Danielle Navarro",
+      "roles": [
+        "cre"
+      ],
+      "directory_id": "danielle-navarro",
+      "email": "d.navarro@unsw.edu.au"
+    }
+  ]
+}

--- a/data/packages/learnres.json
+++ b/data/packages/learnres.json
@@ -1,0 +1,22 @@
+{
+  "name": "learnres",
+  "title": "Templates for different learnr tutorials in Spanish",
+  "description": "Contains templates and themeing files.",
+  "repo_url": "https://github.com/yabellini/learnres",
+  "pkdown_url": null,
+  "bug_reports_url": null,
+  "logo_url": null,
+  "last_updated": "2021-07-19",
+  "authors": [
+    {
+      "name": "Yanina Bellini Saibene",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0000-0000-0000",
+      "directory_id": "yanina-bellini-saibene",
+      "email": "yabellini@gmail.com"
+    }
+  ]
+}

--- a/data/packages/lsr.json
+++ b/data/packages/lsr.json
@@ -1,0 +1,22 @@
+{
+  "name": "lsr",
+  "title": "Companion to \"Learning Statistics with R\"",
+  "description": "A collection of tools intended to make introductory statistics easier to teach, including wrappers for common hypothesis tests and basic data manipulation. It accompanies Navarro, D. J. (2015). Learning Statistics with R: A Tutorial for Psychology Students and Other Beginners, Version 0.6.",
+  "repo_url": "https://github.com/djnavarro/lsr",
+  "pkdown_url": "http://lsr.djnavarro.net/",
+  "bug_reports_url": "https://github.com/djnavarro/lsr/issues",
+  "logo_url": null,
+  "last_updated": "2026-03-21",
+  "authors": [
+    {
+      "name": "Danielle Navarro",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-7648-6578",
+      "directory_id": "danielle-navarro",
+      "email": "djnavarro@protonmail.com"
+    }
+  ]
+}

--- a/data/packages/meetupr.json
+++ b/data/packages/meetupr.json
@@ -1,18 +1,107 @@
 {
-    "name": "meetupr",
-    "description": "Provides programmatic access to the 'Meetup' 'GraphQL' API ",
-    "repo_url": "https://github.com/rladies/meetupr",
-    "pkdown_url": "https://rladies.org/meetupr/",
-    "logo_url": "https://rladies.org/meetupr/logo.png",
-    "maintainers": [
-        {
-            "name": "R-Ladies Global",
-            "email": "info@rladies.org",
-            "social_media": {
-                "bluesky": "rladies.org",
-                "github": "rladies",
-                "mastodon": "@RLadiesGlobal@hachyderm.io"
-            }
-        }
-    ]
+  "name": "meetupr",
+  "title": "Access Meetup Data",
+  "description": "Provides programmatic access to the 'Meetup' 'GraphQL' API (<https://www.meetup.com/graphql/>), enabling users to retrieve information about groups, events, and members from 'Meetup' (<https://www.meetup.com/>). Supports authentication via 'OAuth2' and includes functions for common queries and data manipulation tasks.",
+  "repo_url": "https://github.com/rladies/meetupr",
+  "pkdown_url": "https://rladies.org/meetupr/",
+  "bug_reports_url": "https://github.com/rladies/meetupr/issues",
+  "logo_url": "https://rladies.org/meetupr/logo.png",
+  "last_updated": "2025-12-23",
+  "authors": [
+    {
+      "name": "Athanasia Mo Mowinckel",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-5756-0223",
+      "directory_id": "athanasia-mo-mowinckel",
+      "email": "a.m.mowinckel@psykologi.uio.no"
+    },
+    {
+      "name": "Erin LeDell",
+      "roles": [
+        "aut"
+      ],
+      "directory_id": "erin-ledell"
+    },
+    {
+      "name": "Olga Mierzwa-Sulima",
+      "roles": [
+        "aut"
+      ],
+      "directory_id": "olga-mierzwasulima"
+    },
+    {
+      "name": "Lucy D'Agostino McGowan",
+      "roles": [
+        "aut"
+      ],
+      "directory_id": "lucy-dagostino-mcgowan"
+    },
+    {
+      "name": "Claudia Vitolo",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Gabriela De Queiroz",
+      "roles": [
+        "ctb"
+      ],
+      "directory_id": "gabriela-de-queiroz"
+    },
+    {
+      "name": "Michael Beigelmacher",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Augustina Ragwitz",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Greg Sutcliffe",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Rick Pack",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Ben Ubah",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon"
+    },
+    {
+      "name": "Barret Schloerke",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-9986-114X"
+    },
+    {
+      "name": "R-Ladies Global",
+      "roles": [
+        "cph"
+      ]
+    }
+  ]
 }

--- a/data/packages/messy.json
+++ b/data/packages/messy.json
@@ -1,0 +1,23 @@
+{
+  "name": "messy",
+  "title": "Create Messy Data from Clean Data Frames",
+  "description": "For the purposes of teaching, it is often desirable to show examples of working with messy data and how to clean it. This R package creates messy data from clean, tidy data frames so that students have a clean example to work towards.",
+  "repo_url": "https://github.com/nrennie/messy",
+  "pkdown_url": "https://nrennie.rbind.io/messy/",
+  "bug_reports_url": "https://github.com/nrennie/messy/issues",
+  "logo_url": "https://nrennie.rbind.io/messy/logo.png",
+  "last_updated": "2025-08-29",
+  "authors": [
+    {
+      "name": "Nicola Rennie",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "orcid": "0000-0003-4797-557X",
+      "directory_id": "nicola-rennie",
+      "email": "nrennie35@gmail.com"
+    }
+  ]
+}

--- a/data/packages/monochromeR.json
+++ b/data/packages/monochromeR.json
@@ -1,0 +1,21 @@
+{
+  "name": "monochromeR",
+  "title": "Easily Create, View and Use Monochrome Colour Palettes",
+  "description": "Generate a monochrome palette from a starting colour for a specified number of colours. The package can also be used to display colour palettes in the plot window, with or without hex codes and colour labels.",
+  "repo_url": "https://github.com/cararthompson/monochromeR",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/cararthompson/monochromeR/issues",
+  "logo_url": null,
+  "last_updated": "2023-09-05",
+  "authors": [
+    {
+      "name": "Cara Thompson",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-6472-5073",
+      "email": "packages@cararthompson.com"
+    }
+  ]
+}

--- a/data/packages/namer.json
+++ b/data/packages/namer.json
@@ -1,0 +1,68 @@
+{
+  "name": "namer",
+  "title": "Names Your 'R Markdown' Chunks",
+  "description": "It names the 'R Markdown' chunks of files based on the filename.",
+  "repo_url": "https://github.com/jumpingrivers/namer",
+  "pkdown_url": "https://jumpingrivers.github.io/namer/",
+  "bug_reports_url": "https://github.com/jumpingrivers/namer/issues",
+  "logo_url": null,
+  "last_updated": "2025-01-23",
+  "authors": [
+    {
+      "name": "Colin Gillespie",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "email": "colin@jumpingrivers.com"
+    },
+    {
+      "name": "Steph Locke",
+      "roles": [
+        "aut"
+      ],
+      "directory_id": "steph-locke"
+    },
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon"
+    },
+    {
+      "name": "Ellis Valentiner",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Charlie Hadley",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-3039-6849"
+    },
+    {
+      "name": "Jumping Rivers",
+      "roles": [
+        "fnd"
+      ]
+    },
+    {
+      "name": "Han Oostdijk",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-6710-4566"
+    },
+    {
+      "name": "Patrick Schratz",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0003-0748-6624"
+    }
+  ]
+}

--- a/data/packages/naturecounts.json
+++ b/data/packages/naturecounts.json
@@ -1,0 +1,27 @@
+{
+  "name": "naturecounts",
+  "title": "Access and download data on plant and animal populations from\nNatureCounts",
+  "description": "Access and download data on plant and animal populations from various databases through NatureCounts, a service managed by Bird Studies Canada.",
+  "repo_url": "https://github.com/BirdsCanada/naturecounts",
+  "pkdown_url": "https://naturecounts.ca",
+  "bug_reports_url": null,
+  "logo_url": null,
+  "last_updated": "2026-03-31",
+  "authors": [
+    {
+      "name": "Steffi LaZerte",
+      "roles": [
+        "aut"
+      ],
+      "directory_id": "steffi-lazerte"
+    },
+    {
+      "name": "Denis Lepage",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "email": "dlepage@birdscanada.org"
+    }
+  ]
+}

--- a/data/packages/odbr.json
+++ b/data/packages/odbr.json
@@ -1,0 +1,42 @@
+{
+  "name": "odbr",
+  "title": "Download Data from Brazil's Origin Destination Surveys",
+  "description": "Download data from Brazil's Origin Destination Surveys. The package covers both data from household travel surveys, dictionaries of variables, and the spatial geometries of surveys conducted in different years and across various urban areas in Brazil. For some cities, the package will include enhanced versions of the data sets with variables \"harmonized\" across different years.",
+  "repo_url": "https://github.com/hsvab/odbr",
+  "pkdown_url": "https://hsvab.github.io/odbr/",
+  "bug_reports_url": "https://github.com/hsvab/odbr/issues",
+  "logo_url": "https://hsvab.github.io/odbr/logo.png",
+  "last_updated": "2025-02-14",
+  "authors": [
+    {
+      "name": "Haydee Svab",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "directory_id": "haydee-svab",
+      "email": "hsvab@hsvab.eng.br"
+    },
+    {
+      "name": "Beatriz Milz",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-3064-4486",
+      "directory_id": "beatriz-milz"
+    },
+    {
+      "name": "Diego Rabatone Oliveira",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Rafael H. M. Pereira",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-2125-7465"
+    }
+  ]
+}

--- a/data/packages/opencage.json
+++ b/data/packages/opencage.json
@@ -1,0 +1,55 @@
+{
+  "name": "opencage",
+  "title": "Geocode with the OpenCage API",
+  "description": "Geocode with the OpenCage API, either from place name to longitude and latitude (forward geocoding) or from longitude and latitude to the name and address of a location (reverse geocoding), see <https://opencagedata.com/>.",
+  "repo_url": "https://github.com/ropensci/opencage",
+  "pkdown_url": "https://docs.ropensci.org/opencage/",
+  "bug_reports_url": "https://github.com/ropensci/opencage/issues",
+  "logo_url": "https://docs.ropensci.org/opencage/logo.png",
+  "last_updated": "2021-02-20",
+  "authors": [
+    {
+      "name": "Daniel Possenriede",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-6738-9845",
+      "email": "possenriede+r@gmail.com"
+    },
+    {
+      "name": "Jesse Sadler",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-6081-9681"
+    },
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon"
+    },
+    {
+      "name": "Noam Ross",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Jake Russ",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Julia Silge",
+      "roles": [
+        "rev"
+      ],
+      "directory_id": "julia-silge"
+    }
+  ]
+}

--- a/data/packages/openintro.json
+++ b/data/packages/openintro.json
@@ -1,0 +1,64 @@
+{
+  "name": "openintro",
+  "title": "Datasets and Supplemental Functions from 'OpenIntro' Textbooks\nand Labs",
+  "description": "Supplemental functions and data for 'OpenIntro' resources, which includes open-source textbooks and resources for introductory statistics (<https://www.openintro.org/>). The package contains datasets used in our open-source textbooks along with custom plotting functions for reproducing book figures. Note that many functions and examples include color transparency; some plotting elements may not show up properly (or at all) when run in some versions of Windows operating system.",
+  "repo_url": "https://github.com/OpenIntroStat/openintro/",
+  "pkdown_url": "http://openintrostat.github.io/openintro/",
+  "bug_reports_url": "https://github.com/OpenIntroStat/openintro/issues",
+  "logo_url": "http://openintrostat.github.io/openintro/logo.png",
+  "last_updated": "2024-05-31",
+  "authors": [
+    {
+      "name": "Mine Çetinkaya-Rundel",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-6452-2420",
+      "email": "cetinkaya.mine@gmail.com"
+    },
+    {
+      "name": "David Diez",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Andrew Bray",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Albert Y. Kim",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-7824-306X"
+    },
+    {
+      "name": "Ben Baumer",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Chester Ismay",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Nick Paterno",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Christopher Barr",
+      "roles": [
+        "aut"
+      ]
+    }
+  ]
+}

--- a/data/packages/osmdata.json
+++ b/data/packages/osmdata.json
@@ -1,0 +1,96 @@
+{
+  "name": "osmdata",
+  "title": "Import 'OpenStreetMap' Data as Simple Features or Spatial\nObjects",
+  "description": "Download and import of 'OpenStreetMap' ('OSM') data as 'sf' or 'sp' objects. 'OSM' data are extracted from the 'Overpass' web server (<https://overpass-api.de/>) and processed with very fast 'C++' routines for return to 'R'.",
+  "repo_url": "https://github.com/ropensci/osmdata",
+  "pkdown_url": "https://docs.ropensci.org/osmdata/",
+  "bug_reports_url": "https://github.com/ropensci/osmdata/issues",
+  "logo_url": "https://docs.ropensci.org/osmdata/logo.png",
+  "last_updated": "2025-08-23",
+  "authors": [
+    {
+      "name": "Joan Maspons",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0003-2286-8727",
+      "email": "joanmaspons@gmail.com"
+    },
+    {
+      "name": "Mark Padgham",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Bob Rudis",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Robin Lovelace",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "aut"
+      ],
+      "directory_id": "maelle-salmon"
+    },
+    {
+      "name": "Andrew Smith",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "James Smith",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Andrea Gilardi",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Enrico Spinielli",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Anthony North",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Martin Machyna",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Marcin Kalicinski",
+      "roles": [
+        "ctb",
+        "cph"
+      ]
+    },
+    {
+      "name": "Eli Pousson",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-8280-1706"
+    }
+  ]
+}

--- a/data/packages/overviewR.json
+++ b/data/packages/overviewR.json
@@ -1,0 +1,27 @@
+{
+  "name": "overviewR",
+  "title": "Easily Extracting Information About Your Data",
+  "description": "Makes it easy to display descriptive information on a data set. Getting an easy overview of a data set by displaying and visualizing sample information in different tables (e.g., time and scope conditions). The package also provides publishable 'LaTeX' code to present the sample information.",
+  "repo_url": "https://github.com/cosimameyer/overviewR",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/cosimameyer/overviewR/issues",
+  "logo_url": null,
+  "last_updated": "2026-05-04",
+  "authors": [
+    {
+      "name": "Cosima Meyer",
+      "roles": [
+        "cre",
+        "aut"
+      ],
+      "directory_id": "cosima-meyer",
+      "email": "cosima.meyer@gmail.com"
+    },
+    {
+      "name": "Dennis Hammerschmidt",
+      "roles": [
+        "aut"
+      ]
+    }
+  ]
+}

--- a/data/packages/palmerpenguins.json
+++ b/data/packages/palmerpenguins.json
@@ -1,0 +1,35 @@
+{
+  "name": "palmerpenguins",
+  "title": "Palmer Archipelago (Antarctica) Penguin Data",
+  "description": "Size measurements, clutch observations, and blood isotope ratios for adult foraging Adélie, Chinstrap, and Gentoo penguins observed on islands in the Palmer Archipelago near Palmer Station, Antarctica. Data were collected and made available by Dr. Kristen Gorman and the Palmer Station Long Term Ecological Research (LTER) Program.",
+  "repo_url": "https://github.com/allisonhorst/palmerpenguins",
+  "pkdown_url": "https://allisonhorst.github.io/palmerpenguins/",
+  "bug_reports_url": "https://github.com/allisonhorst/palmerpenguins/issues",
+  "logo_url": "https://allisonhorst.github.io/palmerpenguins/logo.png",
+  "last_updated": "2022-08-15",
+  "authors": [
+    {
+      "name": "Allison Horst",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-6047-5564",
+      "email": "ahorst@ucsb.edu"
+    },
+    {
+      "name": "Alison Hill",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-8082-1890"
+    },
+    {
+      "name": "Kristen Gorman",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-0258-9264"
+    }
+  ]
+}

--- a/data/packages/parmsurvfit.json
+++ b/data/packages/parmsurvfit.json
@@ -1,0 +1,33 @@
+{
+  "name": "parmsurvfit",
+  "title": "Parametric Models for Survival Data",
+  "description": "Executes simple parametric models for right-censored survival data. Functionality emulates capabilities in 'Minitab', including fitting right-censored data, assessing fit, plotting survival functions, and summary statistics and probabilities.",
+  "repo_url": "https://github.com/apjacobson/parmsurvfit",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/apjacobson/parmsurvfit/issues",
+  "logo_url": null,
+  "last_updated": "2018-12-07",
+  "authors": [
+    {
+      "name": "Ashley Jacobson",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "email": "ashleypjacobson@gmail.com"
+    },
+    {
+      "name": "Victor Wilson",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Shannon Pileggi",
+      "roles": [
+        "aut"
+      ],
+      "directory_id": "shannon-pileggi"
+    }
+  ]
+}

--- a/data/packages/pins.json
+++ b/data/packages/pins.json
@@ -1,0 +1,45 @@
+{
+  "name": "pins",
+  "title": "Pin, Discover, and Share Resources",
+  "description": "Publish data sets, models, and other R objects, making it easy to share them across projects and with your colleagues. You can pin objects to a variety of \"boards\", including local folders (to share on a networked drive or with 'DropBox'), 'Posit Connect', 'AWS S3', and more.",
+  "repo_url": "https://github.com/rstudio/pins-r",
+  "pkdown_url": "https://pins.rstudio.com/",
+  "bug_reports_url": "https://github.com/rstudio/pins-r/issues",
+  "logo_url": "https://pins.rstudio.com/logo.png",
+  "last_updated": "2026-03-09",
+  "authors": [
+    {
+      "name": "Julia Silge",
+      "roles": [
+        "cre",
+        "aut"
+      ],
+      "orcid": "0000-0002-3671-836X",
+      "directory_id": "julia-silge",
+      "email": "julia.silge@posit.co"
+    },
+    {
+      "name": "Hadley Wickham",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-4757-117X"
+    },
+    {
+      "name": "Javier Luraschi",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Posit Software"
+    },
+    {
+      "name": "PBC",
+      "roles": [
+        "cph",
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/pkgdown.json
+++ b/data/packages/pkgdown.json
@@ -1,0 +1,59 @@
+{
+  "name": "pkgdown",
+  "title": "Make Static HTML Documentation for a Package",
+  "description": "Generate an attractive and useful website from a source package. 'pkgdown' converts your documentation, vignettes, 'README', and more to 'HTML' making it easy to share information about your package online.",
+  "repo_url": "https://github.com/r-lib/pkgdown",
+  "pkdown_url": "https://pkgdown.r-lib.org/",
+  "bug_reports_url": "https://github.com/r-lib/pkgdown/issues",
+  "logo_url": "https://pkgdown.r-lib.org/logo.png",
+  "last_updated": "2025-11-06",
+  "authors": [
+    {
+      "name": "Hadley Wickham",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0003-4757-117X",
+      "email": "hadley@posit.co"
+    },
+    {
+      "name": "Jay Hesselberth",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-6299-179X"
+    },
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon"
+    },
+    {
+      "name": "Olivier Roy",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Salim Brüggemann",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-5329-5987"
+    },
+    {
+      "name": "Posit Software"
+    },
+    {
+      "name": "PBC",
+      "roles": [
+        "cph",
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/pkgsearch.json
+++ b/data/packages/pkgsearch.json
@@ -1,0 +1,34 @@
+{
+  "name": "pkgsearch",
+  "title": "Search and Query CRAN R Packages",
+  "description": "Search CRAN metadata about packages by keyword, popularity, recent activity, package name and more. Uses the 'R-hub' search server, see <https://r-pkg.org> and the CRAN metadata database, that contains information about CRAN packages. Note that this is _not_ a CRAN project.",
+  "repo_url": "https://github.com/r-hub/pkgsearch",
+  "pkdown_url": "https://r-hub.github.io/pkgsearch/",
+  "bug_reports_url": "https://github.com/r-hub/pkgsearch/issues",
+  "logo_url": null,
+  "last_updated": "2025-04-12",
+  "authors": [
+    {
+      "name": "Gábor Csárdi",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "email": "csardi.gabor@gmail.com"
+    },
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon"
+    },
+    {
+      "name": "R Consortium",
+      "roles": [
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/pregnancy.json
+++ b/data/packages/pregnancy.json
@@ -1,0 +1,23 @@
+{
+  "name": "pregnancy",
+  "title": "Calculate and Track Dates and Medications During Pregnancy",
+  "description": "Provides functionality for calculating pregnancy-related dates and tracking medications during pregnancy and fertility treatment. Calculates due dates from various starting points including last menstrual period and IVF (In Vitro Fertilisation) transfer dates, determines pregnancy progress on any given date, and identifies when specific pregnancy weeks are reached. Includes medication tracking capabilities for individuals undergoing fertility treatment or during pregnancy, allowing users to monitor remaining doses and quantities needed over specified time periods. Designed for those tracking their own pregnancies or supporting partners through the process, making use of options to personalise output messages. For details on due date calculations, see <https://www.acog.org/clinical/clinical-guidance/committee-opinion/articles/2017/05/methods-for-estimating-the-due-date>.",
+  "repo_url": "https://github.com/EllaKaye/pregnancy",
+  "pkdown_url": "https://ellakaye.github.io/pregnancy/",
+  "bug_reports_url": "https://github.com/EllaKaye/pregnancy/issues",
+  "logo_url": "https://ellakaye.github.io/pregnancy/logo.png",
+  "last_updated": "2026-01-15",
+  "authors": [
+    {
+      "name": "Ella Kaye",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "orcid": "0000-0002-7300-3718",
+      "directory_id": "ella-kaye",
+      "email": "ella.kaye@gmail.com"
+    }
+  ]
+}

--- a/data/packages/projmgr.json
+++ b/data/packages/projmgr.json
@@ -1,0 +1,21 @@
+{
+  "name": "projmgr",
+  "title": "Task Tracking and Project Management with GitHub",
+  "description": "Provides programmatic access to 'GitHub' API with a focus on project management. Key functionality includes setting up issues and milestones from R objects or 'YAML' configurations, querying outstanding or completed tasks, and generating progress updates in tables, charts, and RMarkdown reports. Useful for those using 'GitHub' in personal, professional, or academic settings with an emphasis on streamlining the workflow of data analysis projects.",
+  "repo_url": "https://github.com/emilyriederer/projmgr",
+  "pkdown_url": "https://emilyriederer.github.io/projmgr/",
+  "bug_reports_url": "https://github.com/emilyriederer/projmgr/issues",
+  "logo_url": "https://emilyriederer.github.io/projmgr/logo.png",
+  "last_updated": "2025-11-29",
+  "authors": [
+    {
+      "name": "Emily Riederer",
+      "roles": [
+        "cre",
+        "aut"
+      ],
+      "directory_id": "emily-riederer",
+      "email": "emilyriederer@gmail.com"
+    }
+  ]
+}

--- a/data/packages/quadkeyr.json
+++ b/data/packages/quadkeyr.json
@@ -1,0 +1,73 @@
+{
+  "name": "quadkeyr",
+  "title": "Generate Raster Images from QuadKey-Identified Datasets",
+  "description": "A set of functions of increasing complexity allows users to (1) convert QuadKey-identified datasets, based on 'Microsoft's Bing Maps Tile System', into Simple Features data frames, (2) transform Simple Features data frames into rasters, and (3) process multiple 'Meta' ('Facebook') QuadKey-identified human mobility files directly into raster files. For more details, see D’Andrea et al. (2024) <doi:10.21105/joss.06500>.",
+  "repo_url": "https://github.com/ropensci/quadkeyr",
+  "pkdown_url": "https://docs.ropensci.org/quadkeyr/",
+  "bug_reports_url": "https://github.com/ropensci/quadkeyr/issues",
+  "logo_url": "https://docs.ropensci.org/quadkeyr/logo.png",
+  "last_updated": "2025-03-24",
+  "authors": [
+    {
+      "name": "Florencia D'Andrea",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-0041-097X",
+      "directory_id": "florencia-dandrea",
+      "email": "florencia.dandrea@gmail.com"
+    },
+    {
+      "name": "Pilar Fernandez",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-8645-2267",
+      "directory_id": "pilar-fernandez"
+    },
+    {
+      "name": "Maria Paula Caldas",
+      "roles": [
+        "rev"
+      ],
+      "orcid": "0000-0002-1938-6471",
+      "directory_id": "maria-paula-caldas"
+    },
+    {
+      "name": "Vincent van Hees",
+      "roles": [
+        "rev"
+      ],
+      "orcid": "0000-0003-0182-9008"
+    },
+    {
+      "name": "Andrew Pulsipher",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-0773-3210"
+    },
+    {
+      "name": "CDC's Center for Forecasting and Outbreak Analytics",
+      "roles": [
+        "fnd"
+      ]
+    },
+    {
+      "name": "MIDAS-NIH COVID-19 urgent grant program",
+      "roles": [
+        "fnd"
+      ]
+    },
+    {
+      "name": "Paul G. Allen School for Global Health"
+    },
+    {
+      "name": "Washington State University",
+      "roles": [
+        "cph"
+      ]
+    }
+  ]
+}

--- a/data/packages/qualtRics.json
+++ b/data/packages/qualtRics.json
@@ -1,0 +1,71 @@
+{
+  "name": "qualtRics",
+  "title": "Download 'Qualtrics' Survey Data",
+  "description": "Provides functions to access survey results directly into R using the 'Qualtrics' API. 'Qualtrics' <https://www.qualtrics.com/about/> is an online survey and data collection software platform. See <https://api.qualtrics.com/> for more information about the 'Qualtrics' API. This package is community-maintained and is not officially supported by 'Qualtrics'.",
+  "repo_url": "https://github.com/ropensci/qualtRics",
+  "pkdown_url": "https://docs.ropensci.org/qualtRics/",
+  "bug_reports_url": "https://github.com/ropensci/qualtRics/issues",
+  "logo_url": "https://docs.ropensci.org/qualtRics/logo.png",
+  "last_updated": "2025-08-23",
+  "authors": [
+    {
+      "name": "Jasper Ginn",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Jackson Curtis",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Shaun Jackson",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Samuel Kaminsky",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Eric Knudsen",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Joseph O'Brien",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Daniel Seneca",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Julia Silge",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-3671-836X",
+      "directory_id": "julia-silge",
+      "email": "julia.silge@gmail.com"
+    },
+    {
+      "name": "Phoebe Wong",
+      "roles": [
+        "ctb"
+      ],
+      "directory_id": "phoebe-wong"
+    }
+  ]
+}

--- a/data/packages/quartose.json
+++ b/data/packages/quartose.json
@@ -1,0 +1,22 @@
+{
+  "name": "quartose",
+  "title": "Dynamically Generate Quarto Syntax",
+  "description": "Provides helper functions to work programmatically within a quarto document. It allows the user to create section headers, tabsets, divs, and spans, and formats these objects into quarto syntax when printed into a document.",
+  "repo_url": "https://github.com/djnavarro/quartose",
+  "pkdown_url": "https://quartose.djnavarro.net/",
+  "bug_reports_url": "https://github.com/djnavarro/quartose/issues",
+  "logo_url": null,
+  "last_updated": "2025-07-09",
+  "authors": [
+    {
+      "name": "Danielle Navarro",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "directory_id": "danielle-navarro",
+      "email": "djnavarro@protonmail.com"
+    }
+  ]
+}

--- a/data/packages/queue.json
+++ b/data/packages/queue.json
@@ -1,0 +1,22 @@
+{
+  "name": "queue",
+  "title": "Simple Multi-Threaded Task Queuing",
+  "description": "Implements a simple multi-threaded task queue using R6 classes.",
+  "repo_url": "https://github.com/djnavarro/queue",
+  "pkdown_url": "http://djnavarro.net/queue/",
+  "bug_reports_url": "https://github.com/djnavarro/queue/issues",
+  "logo_url": null,
+  "last_updated": "2026-03-21",
+  "authors": [
+    {
+      "name": "Danielle Navarro",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-7648-6578",
+      "directory_id": "danielle-navarro",
+      "email": "djnavarro@protonmail.com"
+    }
+  ]
+}

--- a/data/packages/rainbowr.json
+++ b/data/packages/rainbowr.json
@@ -1,0 +1,22 @@
+{
+  "name": "rainbowr",
+  "title": "Make LGBT Hexes and Flags",
+  "description": "Generates a variety of LGBT flags (e.g., rainbow, transgender) overlaid with the R logo, using the magick package. Also generates hex stickers based on LGBT flags and tilings thereof.",
+  "repo_url": "https://github.com/djnavarro/rainbowr",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/djnavarro/rainbowr/issues",
+  "logo_url": null,
+  "last_updated": "2020-07-07",
+  "authors": [
+    {
+      "name": "Danielle Navarro",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-7648-6578",
+      "directory_id": "danielle-navarro",
+      "email": "d.navarro@unsw.edu.au"
+    }
+  ]
+}

--- a/data/packages/rhub.json
+++ b/data/packages/rhub.json
@@ -1,0 +1,34 @@
+{
+  "name": "rhub",
+  "title": "Tools for R Package Developers",
+  "description": "R-hub v2 uses GitHub Actions to run 'R CMD check' and similar package checks. The 'rhub' package helps you set up R-hub v2 for your R package, and start running checks.",
+  "repo_url": "https://github.com/r-hub/rhub",
+  "pkdown_url": "https://r-hub.github.io/rhub/",
+  "bug_reports_url": "https://github.com/r-hub/rhub/issues",
+  "logo_url": "https://r-hub.github.io/rhub/logo.png",
+  "last_updated": "2025-03-06",
+  "authors": [
+    {
+      "name": "Gábor Csárdi",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "email": "csardi.gabor@gmail.com"
+    },
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon"
+    },
+    {
+      "name": "R Consortium",
+      "roles": [
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/riem.json
+++ b/data/packages/riem.json
@@ -1,0 +1,54 @@
+{
+  "name": "riem",
+  "title": "Accesses Weather Data from the Iowa Environment Mesonet",
+  "description": "Allows to get weather data from Automated Surface Observing System (ASOS) stations (airports) in the whole world thanks to the Iowa Environment Mesonet website.",
+  "repo_url": "https://github.com/ropensci/riem",
+  "pkdown_url": "https://docs.ropensci.org/riem/",
+  "bug_reports_url": "https://github.com/ropensci/riem/issues",
+  "logo_url": "https://docs.ropensci.org/riem/logo.png",
+  "last_updated": "2025-01-31",
+  "authors": [
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon",
+      "email": "maelle.salmon@yahoo.se"
+    },
+    {
+      "name": "Brooke Anderson",
+      "roles": [
+        "rev"
+      ],
+      "directory_id": "brooke-anderson"
+    },
+    {
+      "name": "CHAI Project",
+      "roles": [
+        "fnd"
+      ]
+    },
+    {
+      "name": "rOpenSci",
+      "roles": [
+        "fnd"
+      ]
+    },
+    {
+      "name": "Daryl Herzmann",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Jonathan Elchison",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0009-0004-0787-3426"
+    }
+  ]
+}

--- a/data/packages/roblog.json
+++ b/data/packages/roblog.json
@@ -1,0 +1,54 @@
+{
+  "name": "roblog",
+  "title": "rOpenSci's blog guidance",
+  "description": "It provides templates for roweb2 blogging and help for a GitHub forking workflow.",
+  "repo_url": "https://github.com/ropenscilabs/roblog",
+  "pkdown_url": "https://docs.ropensci.org/roblog/",
+  "bug_reports_url": "https://github.com/ropenscilabs/roblog/issues",
+  "logo_url": "https://docs.ropensci.org/roblog/logo.png",
+  "last_updated": "2026-02-18",
+  "authors": [
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon",
+      "email": "maelle.salmon@yahoo.se"
+    },
+    {
+      "name": "Stefanie Butland",
+      "roles": [
+        "aut"
+      ],
+      "directory_id": "stefanie-butland"
+    },
+    {
+      "name": "rOpenSci",
+      "roles": [
+        "fnd"
+      ]
+    },
+    {
+      "name": "Amanda Dobbyn",
+      "roles": [
+        "ctb"
+      ],
+      "directory_id": "amanda-dobbyn"
+    },
+    {
+      "name": "Christophe Dervieux",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Romain LESUR",
+      "roles": [
+        "ctb"
+      ]
+    }
+  ]
+}

--- a/data/packages/rsample.json
+++ b/data/packages/rsample.json
@@ -1,0 +1,65 @@
+{
+  "name": "rsample",
+  "title": "General Resampling Infrastructure",
+  "description": "Classes and functions to create and summarize different types of resampling objects (e.g. bootstrap, cross-validation).",
+  "repo_url": "https://github.com/tidymodels/rsample",
+  "pkdown_url": "https://rsample.tidymodels.org",
+  "bug_reports_url": "https://github.com/tidymodels/rsample/issues",
+  "logo_url": "https://rsample.tidymodels.org/logo.png",
+  "last_updated": "2026-01-30",
+  "authors": [
+    {
+      "name": "Hannah Frick",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-6049-5258",
+      "directory_id": "hannah-frick",
+      "email": "hannah@posit.co"
+    },
+    {
+      "name": "Fanny Chow",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Max Kuhn",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Michael Mahoney",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-2402-304X"
+    },
+    {
+      "name": "Julia Silge",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-3671-836X",
+      "directory_id": "julia-silge"
+    },
+    {
+      "name": "Hadley Wickham",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Posit Software"
+    },
+    {
+      "name": "PBC",
+      "roles": [
+        "cph",
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/rstanemax.json
+++ b/data/packages/rstanemax.json
@@ -1,0 +1,35 @@
+{
+  "name": "rstanemax",
+  "title": "Emax Model Analysis with 'Stan'",
+  "description": "Perform sigmoidal Emax model fit using 'Stan' in a formula notation, without writing 'Stan' model code.",
+  "repo_url": "https://github.com/yoshidk6/rstanemax",
+  "pkdown_url": "https://yoshidk6.github.io/rstanemax/",
+  "bug_reports_url": "https://github.com/yoshidk6/rstanemax/issues",
+  "logo_url": null,
+  "last_updated": "2025-02-17",
+  "authors": [
+    {
+      "name": "Kenta Yoshida",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0003-4967-3831",
+      "email": "yoshida.kenta.6@gmail.com"
+    },
+    {
+      "name": "Danielle Navarro",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-7648-6578",
+      "directory_id": "danielle-navarro"
+    },
+    {
+      "name": "Trustees of Columbia University",
+      "roles": [
+        "cph"
+      ]
+    }
+  ]
+}

--- a/data/packages/sessioncheck.json
+++ b/data/packages/sessioncheck.json
@@ -1,0 +1,22 @@
+{
+  "name": "sessioncheck",
+  "title": "Checks Session Status",
+  "description": "Provides tools to check variables contained in the user environment, and inspect the currently loaded package namespaces. The intended use is to allow user scripts to throw errors or warnings if unwanted variables exist or if unwanted packages are loaded.",
+  "repo_url": "https://github.com/djnavarro/sessioncheck",
+  "pkdown_url": "https://sessioncheck.djnavarro.net/",
+  "bug_reports_url": "https://github.com/djnavarro/sessioncheck/issues",
+  "logo_url": null,
+  "last_updated": "2026-02-27",
+  "authors": [
+    {
+      "name": "Danielle Navarro",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "directory_id": "danielle-navarro",
+      "email": "djnavarro@protonmail.com"
+    }
+  ]
+}

--- a/data/packages/sfnetworks.json
+++ b/data/packages/sfnetworks.json
@@ -1,0 +1,43 @@
+{
+  "name": "sfnetworks",
+  "title": "Tidy Geospatial Networks",
+  "description": "Provides a tidy approach to spatial network analysis, in the form of classes and functions that enable a seamless interaction between the network analysis package 'tidygraph' and the spatial analysis package 'sf'.",
+  "repo_url": "https://github.com/luukvdmeer/sfnetworks",
+  "pkdown_url": "https://luukvdmeer.github.io/sfnetworks/",
+  "bug_reports_url": "https://github.com/luukvdmeer/sfnetworks/issues/",
+  "logo_url": "https://luukvdmeer.github.io/sfnetworks/logo.png",
+  "last_updated": "2024-12-06",
+  "authors": [
+    {
+      "name": "Lucas van der Meer",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-6336-8628",
+      "email": "luukvandermeer@live.nl"
+    },
+    {
+      "name": "Lorena Abad",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-0554-734X",
+      "directory_id": "lorena-abad"
+    },
+    {
+      "name": "Andrea Gilardi",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-9424-7439"
+    },
+    {
+      "name": "Robin Lovelace",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-5679-6536"
+    }
+  ]
+}

--- a/data/packages/shinyMobile.json
+++ b/data/packages/shinyMobile.json
@@ -1,0 +1,71 @@
+{
+  "name": "shinyMobile",
+  "title": "Mobile Ready 'shiny' Apps with Standalone Capabilities",
+  "description": "Develop outstanding 'shiny' apps for 'iOS' and 'Android' as well as beautiful 'shiny' gadgets. 'shinyMobile' is built on top of the latest 'Framework7' template <https://framework7.io>. Discover 14 new input widgets (sliders, vertical sliders, stepper, grouped action buttons, toggles, picker, smart select, ...), 2 themes (light and dark), 12 new widgets (expandable cards, badges, chips, timelines, gauges, progress bars, ...) combined with the power of server-side notifications such as alerts, modals, toasts, action sheets, sheets (and more) as well as 3 layouts (single, tabs and split).",
+  "repo_url": "https://github.com/RinteRface/shinyMobile",
+  "pkdown_url": "https://rinterface.github.io/shinyMobile/",
+  "bug_reports_url": "https://github.com/RinteRface/shinyMobile/issues",
+  "logo_url": "https://rinterface.github.io/shinyMobile/logo.png",
+  "last_updated": "2024-10-04",
+  "authors": [
+    {
+      "name": "David Granjon",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "email": "dgranjon@ymail.com"
+    },
+    {
+      "name": "Veerle van Leemput",
+      "roles": [
+        "aut"
+      ],
+      "directory_id": "veerle-van-leemput"
+    },
+    {
+      "name": "AthlyticZ",
+      "roles": [
+        "fnd"
+      ]
+    },
+    {
+      "name": "Victor Perrier",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "John Coene",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Isabelle Rudolf",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Dieter Menne",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Marvelapp",
+      "roles": [
+        "ctb",
+        "cph"
+      ]
+    },
+    {
+      "name": "Vladimir Kharlampidi",
+      "roles": [
+        "ctb",
+        "cph"
+      ]
+    }
+  ]
+}

--- a/data/packages/shinymodels.json
+++ b/data/packages/shinymodels.json
@@ -1,0 +1,52 @@
+{
+  "name": "shinymodels",
+  "title": "Interactive Assessments of Models",
+  "description": "Launch a 'shiny' application for 'tidymodels' results. For classification or regression models, the app can be used to determine if there is lack of fit or poorly predicted points.",
+  "repo_url": "https://github.com/tidymodels/shinymodels",
+  "pkdown_url": "https://shinymodels.tidymodels.org",
+  "bug_reports_url": "https://github.com/tidymodels/shinymodels/issues",
+  "logo_url": null,
+  "last_updated": "2024-01-31",
+  "authors": [
+    {
+      "name": "Max Kuhn",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-2402-136X"
+    },
+    {
+      "name": "Shisham Adhikari",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Julia Silge",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-3671-836X",
+      "directory_id": "julia-silge"
+    },
+    {
+      "name": "Simon Couch",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-5676-5107",
+      "email": "simon.couch@posit.co"
+    },
+    {
+      "name": "Posit Software"
+    },
+    {
+      "name": "PBC",
+      "roles": [
+        "cph",
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/siga.json
+++ b/data/packages/siga.json
@@ -1,0 +1,46 @@
+{
+  "name": "siga",
+  "title": "Descargar y Leer Datos del SIGA",
+  "description": "Descarga y lee datos del Sistema de Información y Gestión Agrometeorológica del INTA <http://siga.inta.gob.ar/>.",
+  "repo_url": "https://github.com/AgRoMeteorologiaINTA/siga",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/AgRoMeteorologiaINTA/siga/issues",
+  "logo_url": null,
+  "last_updated": "2024-05-21",
+  "authors": [
+    {
+      "name": "Yanina Bellini Saibene",
+      "roles": [
+        "cre",
+        "ctb"
+      ],
+      "directory_id": "yanina-bellini-saibene",
+      "email": "yabellini@gmail.com"
+    },
+    {
+      "name": "Elio Campitelli",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-7742-9230"
+    },
+    {
+      "name": "Paola Corrales",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Natalia Gattinoni",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "INTA",
+      "roles": [
+        "cph"
+      ]
+    }
+  ]
+}

--- a/data/packages/spatialsample.json
+++ b/data/packages/spatialsample.json
@@ -1,0 +1,39 @@
+{
+  "name": "spatialsample",
+  "title": "Spatial Resampling Infrastructure",
+  "description": "Functions and classes for spatial resampling to use with the 'rsample' package, such as spatial cross-validation (Brenning, 2012) <doi:10.1109/IGARSS.2012.6352393>. The scope of 'rsample' and 'spatialsample' is to provide the basic building blocks for creating and analyzing resamples of a spatial data set, but neither package includes functions for modeling or computing statistics. The resampled spatial data sets created by 'spatialsample' do not contain much overhead in memory.",
+  "repo_url": "https://github.com/tidymodels/spatialsample",
+  "pkdown_url": "https://spatialsample.tidymodels.org",
+  "bug_reports_url": "https://github.com/tidymodels/spatialsample/issues",
+  "logo_url": "https://spatialsample.tidymodels.org/logo.png",
+  "last_updated": "2025-12-02",
+  "authors": [
+    {
+      "name": "Michael Mahoney",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0003-2402-304X",
+      "email": "mike.mahoney.218@gmail.com"
+    },
+    {
+      "name": "Julia Silge",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-3671-836X",
+      "directory_id": "julia-silge"
+    },
+    {
+      "name": "Posit Software"
+    },
+    {
+      "name": "PBC",
+      "roles": [
+        "cph",
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/statsr.json
+++ b/data/packages/statsr.json
@@ -1,0 +1,38 @@
+{
+  "name": "statsr",
+  "title": "Companion Software for the Coursera Statistics with R\nSpecialization",
+  "description": "Data and functions to support Bayesian and frequentist inference and decision making for the Coursera Specialization \"Statistics with R\". See <https://github.com/StatsWithR/statsr> for more information.",
+  "repo_url": "https://github.com/StatsWithR/statsr",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/StatsWithR/statsr/issues",
+  "logo_url": null,
+  "last_updated": "2021-01-22",
+  "authors": [
+    {
+      "name": "Colin Rundel",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Mine Cetinkaya-Rundel",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Merlise Clyde",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "email": "clyde@duke.edu"
+    },
+    {
+      "name": "David Banks",
+      "roles": [
+        "aut"
+      ]
+    }
+  ]
+}

--- a/data/packages/tidylo.json
+++ b/data/packages/tidylo.json
@@ -1,0 +1,36 @@
+{
+  "name": "tidylo",
+  "title": "Weighted Tidy Log Odds Ratio",
+  "description": "How can we measure how the usage or frequency of some feature, such as words, differs across some group or set, such as documents? One option is to use the log odds ratio, but the log odds ratio alone does not account for sampling variability; we haven't counted every feature the same number of times so how do we know which differences are meaningful? Enter the weighted log odds, which 'tidylo' provides an implementation for, using tidy data principles. In particular, here we use the method outlined in Monroe, Colaresi, and Quinn (2008) <doi:10.1093/pan/mpn018> to weight the log odds ratio by a prior. By default, the prior is estimated from the data itself, an empirical Bayes approach, but an uninformative prior is also available.",
+  "repo_url": "https://github.com/juliasilge/tidylo",
+  "pkdown_url": "https://juliasilge.github.io/tidylo/",
+  "bug_reports_url": "https://github.com/juliasilge/tidylo/issues",
+  "logo_url": null,
+  "last_updated": "2022-03-22",
+  "authors": [
+    {
+      "name": "Tyler Schnoebelen",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Julia Silge",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "orcid": "0000-0002-3671-836X",
+      "directory_id": "julia-silge",
+      "email": "julia.silge@gmail.com"
+    },
+    {
+      "name": "Alex Hayes",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-4985-5160"
+    }
+  ]
+}

--- a/data/packages/tidyquintro.json
+++ b/data/packages/tidyquintro.json
@@ -1,0 +1,22 @@
+{
+  "name": "tidyquintro",
+  "title": "Quick Intro to Tidyverse",
+  "description": "A 4 hour workshop with quick introduction to tidyverse.",
+  "repo_url": "https://github.com/drmowinckels/tidyquintro",
+  "pkdown_url": null,
+  "bug_reports_url": null,
+  "logo_url": null,
+  "last_updated": "2022-10-10",
+  "authors": [
+    {
+      "name": "Athanasia Mo Mowinckel",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-5756-0223",
+      "directory_id": "athanasia-mo-mowinckel",
+      "email": "a.m.mowinckel@psykologi.uio.no"
+    }
+  ]
+}

--- a/data/packages/tidytext.json
+++ b/data/packages/tidytext.json
@@ -1,0 +1,73 @@
+{
+  "name": "tidytext",
+  "title": "Text Mining using 'dplyr', 'ggplot2', and Other Tidy Tools",
+  "description": "Using tidy data principles can make many text mining tasks easier, more effective, and consistent with tools already in wide use. Much of the infrastructure needed for text mining with tidy data frames already exists in packages like 'dplyr', 'broom', 'tidyr', and 'ggplot2'. In this package, we provide functions and supporting data sets to allow conversion of text to and from tidy formats, and to switch seamlessly between tidy tools and existing text mining packages.",
+  "repo_url": "https://github.com/juliasilge/tidytext",
+  "pkdown_url": "https://juliasilge.github.io/tidytext/",
+  "bug_reports_url": "https://github.com/juliasilge/tidytext/issues",
+  "logo_url": "https://juliasilge.github.io/tidytext/logo.png",
+  "last_updated": "2026-02-21",
+  "authors": [
+    {
+      "name": "Gabriela De Queiroz",
+      "roles": [
+        "ctb"
+      ],
+      "directory_id": "gabriela-de-queiroz"
+    },
+    {
+      "name": "Colin Fay",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-7343-1846"
+    },
+    {
+      "name": "Emil Hvitfeldt",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Os Keyes",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-5196-609X"
+    },
+    {
+      "name": "Kanishka Misra",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Tim Mastny",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Jeff Erickson",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "David Robinson",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Julia Silge",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-3671-836X",
+      "directory_id": "julia-silge",
+      "email": "julia.silge@gmail.com"
+    }
+  ]
+}

--- a/data/packages/tinkr.json
+++ b/data/packages/tinkr.json
@@ -1,0 +1,53 @@
+{
+  "name": "tinkr",
+  "title": "Cast '(R)Markdown' Files to 'XML' and Back Again",
+  "description": "Parsing '(R)Markdown' files with numerous regular expressions can be fraught with peril, but it does not have to be this way. Converting '(R)Markdown' files to 'XML' using the 'commonmark' package allows in-memory editing via of 'markdown' elements via 'XPath' through the extensible 'R6' class called 'yarn'. These modified 'XML' representations can be written to '(R)Markdown' documents via an 'xslt' stylesheet which implements an extended version of 'GitHub'-flavoured 'markdown' so that you can tinker to your hearts content.",
+  "repo_url": "https://github.com/ropensci/tinkr",
+  "pkdown_url": "https://docs.ropensci.org/tinkr/",
+  "bug_reports_url": "https://github.com/ropensci/tinkr/issues",
+  "logo_url": "https://docs.ropensci.org/tinkr/logo.png",
+  "last_updated": "2025-10-04",
+  "authors": [
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon"
+    },
+    {
+      "name": "Zhian N. Kamvar",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0003-1458-7108",
+      "email": "zkamvar@gmail.com"
+    },
+    {
+      "name": "Jeroen Ooms",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Nick Wellnhofer",
+      "roles": [
+        "cph"
+      ]
+    },
+    {
+      "name": "rOpenSci",
+      "roles": [
+        "fnd"
+      ]
+    },
+    {
+      "name": "Peter Daengeli",
+      "roles": [
+        "ctb"
+      ]
+    }
+  ]
+}

--- a/data/packages/traudem.json
+++ b/data/packages/traudem.json
@@ -1,0 +1,48 @@
+{
+  "name": "traudem",
+  "title": "Use TauDEM",
+  "description": "Simple trustworthy utility functions to use TauDEM (Terrain Analysis Using Digital Elevation Models <https://hydrology.usu.edu/taudem/taudem5/>) command-line interface. This package provides a guide to installation of TauDEM and its dependencies GDAL (Geopatial Data Abstraction Library) and MPI (Message Passing Interface) for different operating systems. Moreover, it checks that TauDEM and its dependencies are correctly installed and included to the PATH, and it provides wrapper commands for calling TauDEM methods from R.",
+  "repo_url": "https://github.com/lucarraro/traudem",
+  "pkdown_url": "https://lucarraro.github.io/traudem/",
+  "bug_reports_url": "https://github.com/lucarraro/traudem/issues",
+  "logo_url": null,
+  "last_updated": "2024-04-24",
+  "authors": [
+    {
+      "name": "Luca Carraro",
+      "roles": [
+        "cre",
+        "aut"
+      ],
+      "email": "Luca.Carraro@eawag.ch"
+    },
+    {
+      "name": "University of Zurich",
+      "roles": [
+        "cph",
+        "fnd"
+      ]
+    },
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon"
+    },
+    {
+      "name": "Wael Sadek",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Kirill Müller",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-1416-3412"
+    }
+  ]
+}

--- a/data/packages/typeR.json
+++ b/data/packages/typeR.json
@@ -1,0 +1,21 @@
+{
+  "name": "typeR",
+  "title": "Simulate Typing Script",
+  "description": "Simulates typing of R script files for presentations and demonstrations. Provides character-by-character animation with optional live code execution. Supports R scripts (.R), R Markdown (.Rmd), and Quarto (.qmd) documents.",
+  "repo_url": "https://github.com/Fgazzelloni/typeR",
+  "pkdown_url": "https://Fgazzelloni.github.io/typeR/",
+  "bug_reports_url": "https://github.com/Fgazzelloni/typeR/issues",
+  "logo_url": "https://Fgazzelloni.github.io/typeR/logo.png",
+  "last_updated": "2026-02-08",
+  "authors": [
+    {
+      "name": "Federica Gazzelloni",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "directory_id": "federica-gazzelloni",
+      "email": "fede.gazzelloni@gmail.com"
+    }
+  ]
+}

--- a/data/packages/uiothemes.json
+++ b/data/packages/uiothemes.json
@@ -1,0 +1,22 @@
+{
+  "name": "uiothemes",
+  "title": "Branding themes for the University of Oslo, Norway",
+  "description": "Contains templates, themeing files and functions. Made specifically for branding purposes for the University of Oslo.",
+  "repo_url": "https://github.com/drmowinckels/uiothemes",
+  "pkdown_url": null,
+  "bug_reports_url": null,
+  "logo_url": null,
+  "last_updated": "2020-10-29",
+  "authors": [
+    {
+      "name": "Athanasia Mo Mowinckel",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-5756-0223",
+      "directory_id": "athanasia-mo-mowinckel",
+      "email": "a.m.mowinckel@psykologi.uio.no"
+    }
+  ]
+}

--- a/data/packages/ukbabynames.json
+++ b/data/packages/ukbabynames.json
@@ -1,0 +1,39 @@
+{
+  "name": "ukbabynames",
+  "title": "UK Baby Names Data",
+  "description": "Full listing of UK baby names occurring more than three times per year between 1974 and 2020, and rankings of baby name popularity by decade from 1904 to 1994.",
+  "repo_url": "https://github.com/mine-cetinkaya-rundel/ukbabynames",
+  "pkdown_url": "https://mine-cetinkaya-rundel.github.io/ukbabynames/",
+  "bug_reports_url": "https://github.com/mine-cetinkaya-rundel/ukbabynames/issues",
+  "logo_url": null,
+  "last_updated": "2022-03-25",
+  "authors": [
+    {
+      "name": "Mine Çetinkaya-Rundel",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-6452-2420",
+      "email": "cetinkaya.mine@gmail.com"
+    },
+    {
+      "name": "Thomas J. Leeper",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Nicholas Goguen-Compagnoni",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Sara Lemus",
+      "roles": [
+        "aut"
+      ]
+    }
+  ]
+}

--- a/data/packages/usdata.json
+++ b/data/packages/usdata.json
@@ -1,0 +1,33 @@
+{
+  "name": "usdata",
+  "title": "Data on the States and Counties of the United States",
+  "description": "Demographic data on the United States at the county and state levels spanning multiple years.",
+  "repo_url": "https://github.com/OpenIntroStat/usdata",
+  "pkdown_url": "https://openintrostat.github.io/usdata/",
+  "bug_reports_url": "https://github.com/OpenIntroStat/usdata/issues",
+  "logo_url": "https://openintrostat.github.io/usdata/logo.png",
+  "last_updated": "2024-06-02",
+  "authors": [
+    {
+      "name": "Mine Çetinkaya-Rundel",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0001-6452-2420",
+      "email": "cetinkaya.mine@gmail.com"
+    },
+    {
+      "name": "David Diez",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Leah Dorazio",
+      "roles": [
+        "aut"
+      ]
+    }
+  ]
+}

--- a/data/packages/vcr.json
+++ b/data/packages/vcr.json
@@ -1,0 +1,55 @@
+{
+  "name": "vcr",
+  "title": "Record 'HTTP' Calls to Disk",
+  "description": "Record test suite 'HTTP' requests and replays them during future runs. A port of the Ruby gem of the same name (<https://github.com/vcr/vcr/>). Works by recording real 'HTTP' requests/responses on disk in 'cassettes', and then replaying matching responses on subsequent requests.",
+  "repo_url": "https://github.com/ropensci/vcr/",
+  "pkdown_url": "https://books.ropensci.org/http-testing/",
+  "bug_reports_url": "https://github.com/ropensci/vcr/issues",
+  "logo_url": null,
+  "last_updated": "2025-12-05",
+  "authors": [
+    {
+      "name": "Scott Chamberlain",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0003-1444-9135",
+      "email": "myrmecocystus@gmail.com"
+    },
+    {
+      "name": "Aaron Wolen",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0003-2542-2202"
+    },
+    {
+      "name": "Maëlle Salmon",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-2815-0399",
+      "directory_id": "maelle-salmon"
+    },
+    {
+      "name": "Daniel Possenriede",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-6738-9845"
+    },
+    {
+      "name": "Hadley Wickham",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "rOpenSci",
+      "roles": [
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/verbaliseR.json
+++ b/data/packages/verbaliseR.json
@@ -1,0 +1,21 @@
+{
+  "name": "verbaliseR",
+  "title": "Make your Text Mighty Fine",
+  "description": "Turn R analysis outputs into full sentences, by writing vectors into in-sentence lists, pluralising words conditionally, spelling out numbers if they are at the start of sentences, writing out dates in full following US or UK style, and managing capitalisations in tidy data.",
+  "repo_url": "https://github.com/cararthompson/verbaliseR",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/cararthompson/verbaliseR/issues",
+  "logo_url": null,
+  "last_updated": "2022-10-04",
+  "authors": [
+    {
+      "name": "Cara Thompson",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-6472-5073",
+      "email": "cara.r.thompson@gmail.com"
+    }
+  ]
+}

--- a/data/packages/vetiver.json
+++ b/data/packages/vetiver.json
@@ -1,0 +1,32 @@
+{
+  "name": "vetiver",
+  "title": "Version, Share, Deploy, and Monitor Models",
+  "description": "The goal of 'vetiver' is to provide fluent tooling to version, share, deploy, and monitor a trained model. Functions handle both recording and checking the model's input data prototype, and predicting from a remote API endpoint. The 'vetiver' package is extensible, with generics that can support many kinds of models.",
+  "repo_url": "https://github.com/rstudio/vetiver-r/",
+  "pkdown_url": "https://vetiver.posit.co",
+  "bug_reports_url": "https://github.com/rstudio/vetiver-r/issues",
+  "logo_url": null,
+  "last_updated": "2025-12-13",
+  "authors": [
+    {
+      "name": "Julia Silge",
+      "roles": [
+        "cre",
+        "aut"
+      ],
+      "orcid": "0000-0002-3671-836X",
+      "directory_id": "julia-silge",
+      "email": "julia.silge@posit.co"
+    },
+    {
+      "name": "Posit Software"
+    },
+    {
+      "name": "PBC",
+      "roles": [
+        "cph",
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/washi.json
+++ b/data/packages/washi.json
@@ -1,0 +1,39 @@
+{
+  "name": "washi",
+  "title": "Washington Soil Health Initiative Branding",
+  "description": "Create plots and tables in a consistent style with WaSHI (Washington Soil Health Initiative) branding. Use 'washi' to easily style your 'ggplot2' plots and 'flextable' tables.",
+  "repo_url": "https://github.com/WA-Department-of-Agriculture/washi",
+  "pkdown_url": "https://wa-department-of-agriculture.github.io/washi/",
+  "bug_reports_url": "https://github.com/WA-Department-of-Agriculture/washi/issues/",
+  "logo_url": "https://wa-department-of-agriculture.github.io/washi/logo.png",
+  "last_updated": "2025-09-16",
+  "authors": [
+    {
+      "name": "Jadey Ryan",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "email": "jryan@agr.wa.gov"
+    },
+    {
+      "name": "Molly McIlquham",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Dani Gelardi",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Washington State Department of Agriculture",
+      "roles": [
+        "cph",
+        "fnd"
+      ]
+    }
+  ]
+}

--- a/data/packages/weathercan.json
+++ b/data/packages/weathercan.json
@@ -1,0 +1,105 @@
+{
+  "name": "weathercan",
+  "title": "Download Weather Data from Environment and Climate Change Canada",
+  "description": "Provides means for downloading historical weather data from the Environment and Climate Change Canada website (<https://climate.weather.gc.ca/historical_data/search_historic_data_e.html>). Data can be downloaded from multiple stations and over large date ranges and automatically processed into a single dataset. Tools are also provided to identify stations either by name or proximity to a location.",
+  "repo_url": "https://github.com/ropensci/weathercan/",
+  "pkdown_url": "https://docs.ropensci.org/weathercan/",
+  "bug_reports_url": "https://github.com/ropensci/weathercan/issues/",
+  "logo_url": "https://docs.ropensci.org/weathercan/logo.png",
+  "last_updated": "2026-01-19",
+  "authors": [
+    {
+      "name": "Steffi LaZerte",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-7690-8360",
+      "directory_id": "steffi-lazerte",
+      "email": "sel@steffilazerte.ca"
+    },
+    {
+      "name": "Sam Albers",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-9270-7884"
+    },
+    {
+      "name": "Nick Brown",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-2719-0671"
+    },
+    {
+      "name": "Kevin Cazelles",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-6619-9874"
+    },
+    {
+      "name": "Richard Littauer",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-5428-7535"
+    },
+    {
+      "name": "Shandiya Balasubramaniam",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-9928-9964"
+    },
+    {
+      "name": "Mark Ciechanowski",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-3732-5939"
+    },
+    {
+      "name": "Jeremy Selva",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-4498-2662"
+    },
+    {
+      "name": "Kelli F. Johnson",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-5149-451X"
+    },
+    {
+      "name": "Russ Allen",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Everett Snieder",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0003-4997-3404"
+    },
+    {
+      "name": "Josh Persi",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-2700-6483"
+    },
+    {
+      "name": "Mahjabin Oyshi",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0009-0000-7992-6727"
+    }
+  ]
+}

--- a/data/packages/widyr.json
+++ b/data/packages/widyr.json
@@ -1,0 +1,34 @@
+{
+  "name": "widyr",
+  "title": "Widen, Process, then Re-Tidy Data",
+  "description": "Encapsulates the pattern of untidying data into a wide matrix, performing some processing, then turning it back into a tidy form. This is useful for several operations such as co-occurrence counts, correlations, or clustering that are mathematically convenient on wide matrices.",
+  "repo_url": "https://github.com/juliasilge/widyr",
+  "pkdown_url": "https://juliasilge.github.io/widyr/",
+  "bug_reports_url": "https://github.com/juliasilge/widyr/issues",
+  "logo_url": null,
+  "last_updated": "2026-03-09",
+  "authors": [
+    {
+      "name": "David Robinson",
+      "roles": [
+        "aut"
+      ]
+    },
+    {
+      "name": "Kanishka Misra",
+      "roles": [
+        "ctb"
+      ]
+    },
+    {
+      "name": "Julia Silge",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-3671-836X",
+      "directory_id": "julia-silge",
+      "email": "julia.silge@gmail.com"
+    }
+  ]
+}

--- a/data/packages/worrrd.json
+++ b/data/packages/worrrd.json
@@ -1,0 +1,29 @@
+{
+  "name": "worrrd",
+  "title": "Generate Wordsearch and Crossword Puzzles",
+  "description": "Generate wordsearch and crossword puzzles using custom lists of words (and clues). Make them easy or hard, and print them to solve offline with paper and pencil!",
+  "repo_url": "https://github.com/anthonypileggi/worrrd",
+  "pkdown_url": "https://www.stochastic-squirrel.com/worrrd/",
+  "bug_reports_url": "https://github.com/anthonypileggi/worrrd/issues",
+  "logo_url": "https://www.stochastic-squirrel.com/worrrd/logo.png",
+  "last_updated": "2022-10-25",
+  "authors": [
+    {
+      "name": "Anthony Pileggi",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "email": "apileggi20@gmail.com"
+    },
+    {
+      "name": "Shannon Pileggi",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0002-7732-4164",
+      "directory_id": "shannon-pileggi"
+    }
+  ]
+}

--- a/data/website/awesome_packages.json
+++ b/data/website/awesome_packages.json
@@ -1,19 +1,4361 @@
 [
   {
+    "name": "airports",
+    "title": "Data on Airports",
+    "description": "Geographic, use, and property related data on airports.",
+    "repo_url": "https://github.com/OpenIntroStat/airports",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/OpenIntroStat/airports/issues",
+    "logo_url": {},
+    "last_updated": "2020-06-29",
+    "authors": [
+      {
+        "name": "Mine Çetinkaya-Rundel",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-6452-2420",
+        "email": "cetinkaya.mine@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "aperol",
+    "title": "Generates Tipsy or Drunk Praise",
+    "description": "This is a joke package, which generates praise using the praise package, then garbles it, as if being delivered by someone tipsy or drunk.",
+    "repo_url": "https://github.com/EllaKaye/aperol",
+    "pkdown_url": "https://ellakaye.github.io/aperol/",
+    "bug_reports_url": "https://github.com/EllaKaye/aperol/issues",
+    "logo_url": "https://ellakaye.github.io/aperol/logo.png",
+    "last_updated": "2025-02-27",
+    "authors": [
+      {
+        "name": "Ella Kaye",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "directory_id": "ella-kaye",
+        "email": "ella.kaye@gmail.com"
+      },
+      {
+        "name": "Kelly Bodwin",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Collin Schwantes",
+        "roles": [
+          "aut"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "artpack",
+    "title": "Creates Generative Art Data",
+    "description": "Create data that displays generative art when mapped into a 'ggplot2' plot. Functionality includes specialized data frame creation for geometric shapes, tools that define artistic color palettes, tools for geometrically transforming data, and other miscellaneous tools that are helpful when using 'ggplot2' for generative art.",
+    "repo_url": "https://github.com/Meghansaha/artpack",
+    "pkdown_url": "https://meghansaha.github.io/artpack/",
+    "bug_reports_url": "https://github.com/Meghansaha/artpack/issues",
+    "logo_url": "https://meghansaha.github.io/artpack/logo.png",
+    "last_updated": "2025-09-17",
+    "authors": [
+      {
+        "name": "Meghan Harris",
+        "roles": [
+          "aut",
+          "cre",
+          "cph"
+        ],
+        "orcid": "0000-0003-3922-8101",
+        "directory_id": "meghan-harris",
+        "email": "meghanha01@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "arttools",
+    "title": "Tools For Generative Art Workflows",
+    "description": "A personal-use package for managing generative art workflows.",
+    "repo_url": "https://github.com/djnavarro/arttools",
+    "pkdown_url": "https://arttools.djnavarro.net/",
+    "bug_reports_url": "https://github.com/djnavarro/arttools/issues",
+    "logo_url": {},
+    "last_updated": "2026-03-21",
+    "authors": [
+      {
+        "name": "Danielle Navarro",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-7648-6578",
+        "directory_id": "danielle-navarro",
+        "email": "djnavarro@protonmail.com"
+      }
+    ]
+  },
+  {
+    "name": "ARUtools",
+    "title": "Management and Processing of Autonomous Recording Unit (ARU)\nData",
+    "description": "Parse Autonomous Recording Unit (ARU) data and for sub-sampling recordings. Extract Metadata from your recordings, select a subset of recordings for interpretation, and prepare files for processing on the 'WildTrax' <https://wildtrax.ca/> platform. Read and process metadata from recordings collected using the SongMeter and BAR-LT types of ARUs.",
+    "repo_url": "https://github.com/ARUtools/ARUtools",
+    "pkdown_url": "https://arutools.github.io/ARUtools/",
+    "bug_reports_url": "https://github.com/ARUtools/ARUtools/issues",
+    "logo_url": "https://arutools.github.io/ARUtools/logo.png",
+    "last_updated": "2025-07-28",
+    "authors": [
+      {
+        "name": "David Hope",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-2140-4261",
+        "email": "david.hope@ec.gc.ca"
+      },
+      {
+        "name": "Steffi LaZerte",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-7690-8360",
+        "directory_id": "steffi-lazerte"
+      },
+      {
+        "name": "Government of Canada",
+        "roles": [
+          "cph",
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "asciify",
+    "title": "Make ASCII Art From Images",
+    "description": "Takes an arbitrary image as input and constructs an text-based approximation to the image using the imager package.",
+    "repo_url": "https://github.com/djnavarro/asciify",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/djnavarro/asciify/issues",
+    "logo_url": {},
+    "last_updated": "2020-04-23",
+    "authors": [
+      {
+        "name": "Danielle Navarro",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-7648-6578",
+        "directory_id": "danielle-navarro",
+        "email": "d.navarro@unsw.edu.au"
+      }
+    ]
+  },
+  {
+    "name": "bakeoff",
+    "title": "Data from \"The Great British Bake Off\"",
+    "description": "Data about the bakers, challenges, and ratings for \"The Great British Bake Off\", from Wikipedia <https://en.wikipedia.org/wiki/The_Great_British_Bake_Off>.",
+    "repo_url": "https://github.com/apreshill/bakeoff",
+    "pkdown_url": "https://bakeoff.netlify.app/",
+    "bug_reports_url": "https://github.com/apreshill/bakeoff/issues",
+    "logo_url": "https://bakeoff.netlify.app/logo.png",
+    "last_updated": "2022-11-02",
+    "authors": [
+      {
+        "name": "Alison Hill",
+        "roles": [
+          "aut",
+          "cre",
+          "cph"
+        ],
+        "orcid": "0000-0002-8082-1890",
+        "email": "apreshill@gmail.com"
+      },
+      {
+        "name": "Chester Ismay",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-2820-2547"
+      },
+      {
+        "name": "Richard Iannone",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-3925-190X"
+      }
+    ]
+  },
+  {
+    "name": "basepenguins",
+    "title": "Convert Files that Use 'palmerpenguins' to Work with 'datasets'",
+    "description": "From 'R' 4.5.0, the 'datasets' package includes the penguins and penguins_raw data sets popularised in the 'palmerpenguins' package. 'basepenguins' takes files that use the 'palmerpenguins' package and converts them to work with the versions from 'datasets' ('R' >= 4.5.0). It does this by removing calls to library(palmerpenguins) and making the necessary changes to column names. Additionally, it provides helper functions to define new files paths for saving the output and a directory of example files to experiment with.",
+    "repo_url": "https://github.com/EllaKaye/basepenguins",
+    "pkdown_url": "https://ellakaye.github.io/basepenguins/",
+    "bug_reports_url": "https://github.com/EllaKaye/basepenguins/issues",
+    "logo_url": "https://ellakaye.github.io/basepenguins/logo.png",
+    "last_updated": "2025-04-10",
+    "authors": [
+      {
+        "name": "Ella Kaye",
+        "roles": [
+          "aut",
+          "cre",
+          "cph"
+        ],
+        "orcid": "0000-0002-7300-3718",
+        "directory_id": "ella-kaye",
+        "email": "ella.kaye@gmail.com"
+      },
+      {
+        "name": "Heather Turner",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-1256-3375",
+        "directory_id": "heather-turner"
+      },
+      {
+        "name": "Achim Zeileis",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0003-0918-3766"
+      }
+    ]
+  },
+  {
+    "name": "BayesERtools",
+    "title": "Bayesian Exposure-Response Analysis Tools",
+    "description": "Suite of tools that facilitate exposure-response analysis using Bayesian methods. The package provides a streamlined workflow for fitting types of models that are commonly used in exposure-response analysis - linear and Emax for continuous endpoints, logistic linear and logistic Emax for binary endpoints, as well as performing simulation and visualization. Learn more about the workflow at <https://genentech.github.io/BayesERbook/>.",
+    "repo_url": {},
+    "pkdown_url": "https://genentech.github.io/BayesERtools/",
+    "bug_reports_url": {},
+    "logo_url": "https://genentech.github.io/BayesERtools/logo.png",
+    "last_updated": "2026-04-23",
+    "authors": [
+      {
+        "name": "Kenta Yoshida",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0003-4967-3831",
+        "email": "yoshida.kenta.6@gmail.com"
+      },
+      {
+        "name": "François Mercier",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-5685-1408"
+      },
+      {
+        "name": "Danielle Navarro",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0001-7648-6578",
+        "directory_id": "danielle-navarro"
+      },
+      {
+        "name": "Genentech"
+      },
+      {
+        "name": "Inc.",
+        "roles": [
+          "cph"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "bayesrules",
+    "title": "Datasets and Supplemental Functions from Bayes Rules! Book",
+    "description": "Provides datasets and functions used for analysis and visualizations in the Bayes Rules! book (<https://www.bayesrulesbook.com>). The package contains a set of functions that summarize and plot Bayesian models from some conjugate families and another set of functions for evaluation of some Bayesian models.",
+    "repo_url": "https://github.com/bayes-rules/bayesrules/",
+    "pkdown_url": "https://bayes-rules.github.io/bayesrules/docs/",
+    "bug_reports_url": "https://github.com/bayes-rules/bayesrules/issues",
+    "logo_url": {},
+    "last_updated": "2026-01-20",
+    "authors": [
+      {
+        "name": "Mine Dogucu",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-8007-934X",
+        "directory_id": "mine-dogucu",
+        "email": "mdogucu@gmail.com"
+      },
+      {
+        "name": "Alicia Johnson",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Miles Ott",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-4457-6565"
+      }
+    ]
+  },
+  {
+    "name": "bcaquiferdata",
+    "title": "BC Aquifer data tools",
+    "description": "Set of tools for processing BC Aquifer lithology and yield data.",
+    "repo_url": "https://github.com/bcgov/bcaquiferdata",
+    "pkdown_url": "http://bcgov.github.io/bcaquiferdata/",
+    "bug_reports_url": {},
+    "logo_url": {},
+    "last_updated": "2026-02-06",
+    "authors": [
+      {
+        "name": "Steffi LaZerte",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-7690-8360",
+        "directory_id": "steffi-lazerte",
+        "email": "sel@steffilazerte.ca"
+      },
+      {
+        "name": "Christine Bieber",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Province of British Columbia",
+        "roles": [
+          "cph"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "bcgwcat",
+    "title": "BC Groundwater Chemistry Analysis Tool",
+    "description": "Set of tools for working with groundwater chemstry data from the BC Government Environmental Monitoring System (EMS). Download EMS data and a) export for use in AquaChem, b) view water quality summaries, c) create piper and stiff plots.",
+    "repo_url": "https://github.com/bcgov/bcgwcat/",
+    "pkdown_url": "https://bcgov.github.io/bcgwcat/",
+    "bug_reports_url": {},
+    "logo_url": {},
+    "last_updated": "2025-02-12",
+    "authors": [
+      {
+        "name": "Steffi LaZerte",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-7690-8360",
+        "directory_id": "steffi-lazerte",
+        "email": "sel@steffilazerte.ca"
+      },
+      {
+        "name": "Andarge Baye",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Province of British Columbia",
+        "roles": [
+          "cph"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "bcgwlreports",
+    "title": "Create BC Groundwater Level Reports",
+    "description": "Fetch data, calculate historical percentiles and create reports of BC groundwater levels for set dates.",
+    "repo_url": "https://github.com/bcgov/bcgwlreports",
+    "pkdown_url": {},
+    "bug_reports_url": {},
+    "logo_url": {},
+    "last_updated": "2024-08-07",
+    "authors": [
+      {
+        "name": "Steffi LaZerte",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-7690-8360",
+        "directory_id": "steffi-lazerte",
+        "email": "steffi@steffi.ca"
+      },
+      {
+        "name": "Jon Goetz",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-4993-1119"
+      }
+    ]
+  },
+  {
+    "name": "BradleyTerryScalable",
+    "title": "Fits the Bradley-Terry Model to Potentially Large and Sparse\nNetworks of Comparison Data",
+    "description": "Facilities are provided for fitting the simple, unstructured Bradley-Terry model to networks of binary comparisons. The implemented methods are designed to scale well to large, potentially sparse, networks. A fairly high degree of scalability is achieved through the use of EM and MM algorithms, which are relatively undemanding in terms of memory usage (relative to some other commonly used methods such as iterative weighted least squares, for example). Both maximum likelihood and Bayesian MAP estimation methods are implemented. The package provides various standard methods for a newly defined 'btfit' model class, such as the extraction and summarisation of model parameters and the simulation of new datasets from a fitted model. Tools are also provided for reshaping data into the newly defined \"btdata\" class, and for analysing the comparison network, prior to fitting the Bradley-Terry model. This package complements, rather than replaces, the existing 'BradleyTerry2' package. (BradleyTerry2 has rather different aims, which are mainly the specification and fitting of \"structured\" Bradley-Terry models in which the strength parameters depend on covariates.)",
+    "repo_url": "https://github.com/EllaKaye/BradleyTerryScalable",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/EllaKaye/BradleyTerryScalable/issues",
+    "logo_url": {},
+    "last_updated": "2022-05-29",
+    "authors": [
+      {
+        "name": "Ella Kaye",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "directory_id": "ella-kaye",
+        "email": "E.Kaye.1@warwick.ac.uk"
+      },
+      {
+        "name": "David Firth",
+        "roles": [
+          "aut"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "bs4cards",
+    "title": "Generate Bootstrap Cards",
+    "description": "Allows the user to generate bootstrap cards within R markdown documents. Intended for use in conjunction with R markdown HTML outputs and other formats that support the bootstrap 4 library.",
+    "repo_url": "https://github.com/djnavarro/bs4cards",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/djnavarro/bs4cards/issues",
+    "logo_url": {},
+    "last_updated": "2021-11-30",
+    "authors": [
+      {
+        "name": "Danielle Navarro",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-7648-6578",
+        "directory_id": "danielle-navarro",
+        "email": "djnavarro@protonmail.com"
+      }
+    ]
+  },
+  {
+    "name": "bundle",
+    "title": "Serialize Model Objects with a Consistent Interface",
+    "description": "Typically, models in 'R' exist in memory and can be saved via regular 'R' serialization. However, some models store information in locations that cannot be saved using 'R' serialization alone. The goal of 'bundle' is to provide a common interface to capture this information, situate it within a portable object, and restore it for use in new settings.",
+    "repo_url": "https://github.com/rstudio/bundle",
+    "pkdown_url": "https://rstudio.github.io/bundle/",
+    "bug_reports_url": "https://github.com/rstudio/bundle/issues",
+    "logo_url": {},
+    "last_updated": "2025-12-10",
+    "authors": [
+      {
+        "name": "Julia Silge",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-3671-836X",
+        "directory_id": "julia-silge",
+        "email": "julia.silge@posit.co"
+      },
+      {
+        "name": "Simon Couch",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Qiushi Yan",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Max Kuhn",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Posit Software"
+      },
+      {
+        "name": "PBC",
+        "roles": [
+          "cph",
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "butcher",
+    "title": "Model Butcher",
+    "description": "Provides a set of S3 generics to axe components of fitted model objects and help reduce the size of model objects saved to disk.",
+    "repo_url": "https://github.com/tidymodels/butcher",
+    "pkdown_url": "https://butcher.tidymodels.org/",
+    "bug_reports_url": "https://github.com/tidymodels/butcher/issues",
+    "logo_url": "https://butcher.tidymodels.org/logo.png",
+    "last_updated": "2025-12-09",
+    "authors": [
+      {
+        "name": "Joyce Cahoon",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0001-7217-4702"
+      },
+      {
+        "name": "Davis Vaughan",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Max Kuhn",
+        "roles": [
+          "cre",
+          "aut"
+        ],
+        "orcid": "0000-0003-2402-136X",
+        "email": "max@posit.co"
+      },
+      {
+        "name": "Alex Hayes",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Julia Silge",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-3671-836X",
+        "directory_id": "julia-silge"
+      },
+      {
+        "name": "Posit Software"
+      },
+      {
+        "name": "PBC",
+        "roles": [
+          "cph",
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "capesData",
+    "title": "Data on Scholarships in CAPES International Mobility Programs",
+    "description": "Information on activities to promote scholarships in Brazil and abroad for international mobility programs, recorded in Capes' computerized payment systems. The CAPES database refers to international mobility programs for the period from 2010 to 2019 <https://dadosabertos.capes.gov.br/dataset/>.",
+    "repo_url": {},
+    "pkdown_url": {},
+    "bug_reports_url": {},
+    "logo_url": {},
+    "last_updated": "2024-08-28",
+    "authors": [
+      {
+        "name": "Leonardo Biazoli",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0003-4069-111X",
+        "email": "leonardobiazoli19@gmail.com"
+      },
+      {
+        "name": "Mine Çetinkaya-Rundel",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0001-6452-2420"
+      },
+      {
+        "name": "Eric Fernandes de Mello Araujo",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-4263-9075"
+      },
+      {
+        "name": "Izabela R. Cardoso de Oliveira",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-3254-2827"
+      }
+    ]
+  },
+  {
+    "name": "cereal",
+    "title": "Serialize 'vctrs' Objects to 'JSON'",
+    "description": "The 'vctrs' package provides a concept of vector prototype that can be especially useful when deploying models and code. Serialize these object prototypes to 'JSON' so they can be used to check and coerce data in production systems, and deserialize 'JSON' back to the correct object prototypes.",
+    "repo_url": "https://github.com/r-lib/cereal/",
+    "pkdown_url": "https://r-lib.github.io/cereal/",
+    "bug_reports_url": "https://github.com/r-lib/cereal/issues",
+    "logo_url": {},
+    "last_updated": "2023-06-09",
+    "authors": [
+      {
+        "name": "Julia Silge",
+        "roles": [
+          "cre",
+          "aut"
+        ],
+        "orcid": "0000-0002-3671-836X",
+        "directory_id": "julia-silge",
+        "email": "julia.silge@posit.co"
+      },
+      {
+        "name": "Davis Vaughan",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Posit Software"
+      },
+      {
+        "name": "PBC",
+        "roles": [
+          "cph",
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "cherryblossom",
+    "title": "Cherry Blossom Run Race Results",
+    "description": "Race results of the Cherry Blossom Run, which is an annual road race that takes place in Washington, DC.",
+    "repo_url": "https://github.com/OpenIntroStat/cherryblossom",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/OpenIntroStat/cherryblossom/issues",
+    "logo_url": {},
+    "last_updated": "2020-06-25",
+    "authors": [
+      {
+        "name": "Mine Çetinkaya-Rundel",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-6452-2420",
+        "email": "cetinkaya.mine@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "codemeta",
+    "title": "A Smaller 'codemetar' Package",
+    "description": "The 'Codemeta' Project defines a 'JSON-LD' format for describing software metadata, as detailed at <https://codemeta.github.io>. This package provides core utilities to generate this metadata with a minimum of dependencies.",
+    "repo_url": "https://github.com/cboettig/codemeta",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/cboettig/codemeta/issues",
+    "logo_url": {},
+    "last_updated": "2021-12-22",
+    "authors": [
+      {
+        "name": "Carl Boettiger",
+        "roles": [
+          "aut",
+          "cre",
+          "cph"
+        ],
+        "orcid": "0000-0002-1642-628X",
+        "email": "cboettig@gmail.com"
+      },
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "ctb",
+          "aut"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon"
+      },
+      {
+        "name": "Katrin Leinweber",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0001-5135-5758"
+      },
+      {
+        "name": "Noam Ross",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-2136-0000"
+      },
+      {
+        "name": "Arfon Smith",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Jeroen Ooms",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-4035-0289"
+      },
+      {
+        "name": "Sebastian Meyer",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-1791-9449"
+      },
+      {
+        "name": "Michael Rustler",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0003-0647-7726"
+      },
+      {
+        "name": "Hauke Sonnenberg",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0001-9134-2871"
+      },
+      {
+        "name": "Sebastian Kreutzer",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-0734-2199"
+      },
+      {
+        "name": "rOpenSci",
+        "roles": [
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "codemetar",
+    "title": "Generate 'CodeMeta' Metadata for R Packages",
+    "description": "The 'Codemeta' Project defines a 'JSON-LD' format for describing software metadata, as detailed at <https://codemeta.github.io>. This package provides utilities to generate, parse, and modify 'codemeta.json' files automatically for R packages, as well as tools and examples for working with 'codemeta.json' 'JSON-LD' more generally.",
+    "repo_url": "https://github.com/ropensci/codemetar",
+    "pkdown_url": "https://docs.ropensci.org/codemetar/",
+    "bug_reports_url": "https://github.com/ropensci/codemetar/issues",
+    "logo_url": "https://docs.ropensci.org/codemetar/logo.png",
+    "last_updated": "2026-02-11",
+    "authors": [
+      {
+        "name": "Carl Boettiger",
+        "roles": [
+          "aut",
+          "cre",
+          "cph"
+        ],
+        "orcid": "0000-0002-1642-628X",
+        "email": "cboettig@gmail.com"
+      },
+      {
+        "name": "Anna Krystalli",
+        "roles": [
+          "rev",
+          "ctb"
+        ],
+        "orcid": "0000-0002-2378-4915"
+      },
+      {
+        "name": "Toph Allen",
+        "roles": [
+          "rev"
+        ],
+        "orcid": "0000-0003-4580-091X"
+      },
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "ctb",
+          "aut"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon"
+      },
+      {
+        "name": "rOpenSci",
+        "roles": [
+          "fnd"
+        ]
+      },
+      {
+        "name": "Katrin Leinweber",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0001-5135-5758"
+      },
+      {
+        "name": "Noam Ross",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-2136-0000"
+      },
+      {
+        "name": "Arfon Smith",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Jeroen Ooms",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-4035-0289"
+      },
+      {
+        "name": "Sebastian Meyer",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-1791-9449"
+      },
+      {
+        "name": "Michael Rustler",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0003-0647-7726"
+      },
+      {
+        "name": "Hauke Sonnenberg",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0001-9134-2871"
+      },
+      {
+        "name": "Sebastian Kreutzer",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-0734-2199"
+      },
+      {
+        "name": "Thierry Onkelinx",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0001-8804-4216"
+      }
+    ]
+  },
+  {
+    "name": "colorhex",
+    "title": "Colors and Palettes from Color-Hex",
+    "description": "The website <https://www.color-hex.com> is a great resource of hex colour codes and palettes. This package allows you to retrieve palettes and colour information from the website directly from R. There are also custom scale-functions for 'ggplot2'.",
+    "repo_url": "https://github.com/drmowinckels/colorhex",
+    "pkdown_url": "https://drmowinckels.github.io/colorhex/",
+    "bug_reports_url": "https://github.com/drmowinckels/colorhex/issues",
+    "logo_url": {},
+    "last_updated": "2023-09-15",
+    "authors": [
+      {
+        "name": "Athanasia Mo Mowinckel",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-5756-0223",
+        "directory_id": "athanasia-mo-mowinckel",
+        "email": "a.m.mowinckel@psykologi.uio.no"
+      },
+      {
+        "name": "Julia Romanowska",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0001-6733-1953",
+        "directory_id": "julia-romanowska"
+      }
+    ]
+  },
+  {
+    "name": "cransays",
+    "title": "Creates an Overview of CRAN Incoming Submissions",
+    "description": "It scrapes the CRAN incoming FTP folder to find where each submission is.",
+    "repo_url": "https://github.com/r-hub/cransays",
+    "pkdown_url": "https://r-hub.github.io/cransays/",
+    "bug_reports_url": "https://github.com/r-hub/cransays/issues",
+    "logo_url": {},
+    "last_updated": "2025-12-26",
+    "authors": [
+      {
+        "name": "Hugo Gruson",
+        "roles": [
+          "cre",
+          "aut"
+        ],
+        "orcid": "0000-0002-4094-1476",
+        "email": "hugo.gruson+R@normalesup.org"
+      },
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "aut",
+          "ccp"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon"
+      },
+      {
+        "name": "Locke Data",
+        "roles": [
+          "fnd"
+        ]
+      },
+      {
+        "name": "Stephanie Locke",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-2387-3723"
+      },
+      {
+        "name": "Mitchell O'Hara-Wild",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0001-6729-7695"
+      },
+      {
+        "name": "Lluís Revilla Sancho",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0001-9747-2570"
+      },
+      {
+        "name": "Jim Hester",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-2739-7082"
+      },
+      {
+        "name": "Hadley Wickham",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0003-4757-117X"
+      }
+    ]
+  },
+  {
+    "name": "dados",
+    "title": "Translate Datasets to Portuguese",
+    "description": "Este pacote traduz os seguintes conjuntos de dados: 'airlines', 'airports', 'ames_raw', 'AwardsManagers', 'babynames', 'Batting', 'diamonds', 'faithful', 'fueleconomy', 'Fielding', 'flights', 'gapminder', 'gss_cat', 'iris', 'Managers', 'mpg', 'mtcars', 'atmos', 'penguins', 'People, 'Pitching', 'pixarfilms','planes', 'presidential', 'table1', 'table2', 'table3', 'table4a', 'table4b', 'table5', 'vehicles', 'weather', 'who'. English: It provides a Portuguese translated version of the datasets listed above.",
+    "repo_url": "https://github.com/cienciadedatos/dados",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/cienciadedatos/dados/issues",
+    "logo_url": {},
+    "last_updated": "2022-02-24",
+    "authors": [
+      {
+        "name": "Riva Quiroga",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-1147-4135",
+        "directory_id": "riva-quiroga",
+        "email": "riva.quiroga@uc.cl"
+      },
+      {
+        "name": "Sara Mortara",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0001-6221-7537"
+      },
+      {
+        "name": "Beatriz Milz",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-3064-4486",
+        "directory_id": "beatriz-milz"
+      },
+      {
+        "name": "Andrea Sánchez-Tapia",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-3521-4338",
+        "directory_id": "andrea-sancheztapia"
+      },
+      {
+        "name": "Alejandra Andrea Tapia Silva",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-0762-7618"
+      },
+      {
+        "name": "Beatriz Maurer Costa",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Jean Prado",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-7928-774X"
+      },
+      {
+        "name": "Renata Hirota",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-3589-3246",
+        "directory_id": "renata-hirota"
+      },
+      {
+        "name": "William Amorim",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-0543-3473"
+      },
+      {
+        "name": "Emmanuelle Rodrigues Nunes",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0001-5994-352X",
+        "directory_id": "emmanuelle-rodrigues-nunes"
+      }
+    ]
+  },
+  {
+    "name": "dataspice",
+    "title": "Create Lightweight Schema.org Descriptions of Data",
+    "description": "The goal of 'dataspice' is to make it easier for researchers to create basic, lightweight, and concise metadata files for their datasets. These basic files can then be used to make useful information available during analysis, create a helpful dataset \"README\" webpage, and produce more complex metadata formats to aid dataset discovery. Metadata fields are based on the 'Schema.org' and 'Ecological Metadata Language' standards.",
+    "repo_url": "https://github.com/ropensci/dataspice",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/ropensci/dataspice/issues",
+    "logo_url": {},
+    "last_updated": "2025-09-23",
+    "authors": [
+      {
+        "name": "Carl Boettiger",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Scott Chamberlain",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Auriel Fournier",
+        "roles": [
+          "aut"
+        ],
+        "directory_id": "auriel-fournier"
+      },
+      {
+        "name": "Kelly Hondula",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Anna Krystalli",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Bryce Mecum",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "email": "brycemecum@gmail.com"
+      },
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "aut"
+        ],
+        "directory_id": "maelle-salmon"
+      },
+      {
+        "name": "Kate Webbink",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Kara Woo",
+        "roles": [
+          "aut"
+        ],
+        "directory_id": "kara-woo"
+      },
+      {
+        "name": "Irene Steves",
+        "roles": [
+          "ctb"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "emodnet.wfs",
+    "title": "Access 'EMODnet' Web Feature Service Data",
+    "description": "Access and interrogate 'EMODnet' (European Marine Observation and Data Network) Web Feature Service data <https://emodnet.ec.europa.eu/en/emodnet-web-service-documentation#data-download-services>. This includes listing existing data sources, and getting data from each of them.",
+    "repo_url": "https://github.com/EMODnet/emodnet.wfs",
+    "pkdown_url": "https://docs.ropensci.org/emodnet.wfs/",
+    "bug_reports_url": "https://github.com/EMODnet/emodnet.wfs/issues",
+    "logo_url": "https://docs.ropensci.org/emodnet.wfs/logo.svg",
+    "last_updated": "2026-03-26",
+    "authors": [
+      {
+        "name": "Joana Beja",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-5196-8447",
+        "email": "joana.beja@vliz.be"
+      },
+      {
+        "name": "Anna Krystalli",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-2378-4915"
+      },
+      {
+        "name": "Salvador Fernández-Bejarano",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-0535-7677"
+      },
+      {
+        "name": "Thomas J Webb",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "European Marine Observation Data Network",
+        "roles": [
+          "cph"
+        ]
+      },
+      {
+        "name": "VLIZ",
+        "roles": [
+          "fnd"
+        ]
+      },
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon"
+      },
+      {
+        "name": "Alec L. Robitaille",
+        "roles": [
+          "rev"
+        ],
+        "orcid": "0000-0002-4706-1762"
+      },
+      {
+        "name": "Liz Hare",
+        "roles": [
+          "rev"
+        ],
+        "orcid": "0000-0002-3978-2543"
+      },
+      {
+        "name": "François Michonneau",
+        "roles": [
+          "rev"
+        ],
+        "orcid": "0000-0002-9092-966X"
+      }
+    ]
+  },
+  {
+    "name": "flametree",
+    "title": "Generate Random Tree-Like Images",
+    "description": "A generative art system for producing tree-like images using an L-system to create the structures. The package includes tools for generating the data structures and visualise them in a variety of styles.",
+    "repo_url": "https://github.com/djnavarro/flametree",
+    "pkdown_url": "https://flametree.djnavarro.net/",
+    "bug_reports_url": "https://github.com/djnavarro/flametree/issues",
+    "logo_url": {},
+    "last_updated": "2026-03-21",
+    "authors": [
+      {
+        "name": "Danielle Navarro",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-7648-6578",
+        "directory_id": "danielle-navarro",
+        "email": "djnavarro@protonmail.com"
+      }
+    ]
+  },
+  {
+    "name": "ggauto",
+    "title": "Automatically Create and Style 'ggplot2' Charts",
+    "description": "Automatically choose an appropriate chart type based on the types and values in the data. Apply more accessible default styling and colours to 'ggplot2' charts.",
+    "repo_url": "https://github.com/nrennie/ggauto",
+    "pkdown_url": "https://nrennie.rbind.io/ggauto/",
+    "bug_reports_url": "https://github.com/nrennie/ggauto/issues",
+    "logo_url": "https://nrennie.rbind.io/ggauto/logo.png",
+    "last_updated": "2026-04-24",
+    "authors": [
+      {
+        "name": "Nicola Rennie",
+        "roles": [
+          "aut",
+          "cre",
+          "cph"
+        ],
+        "directory_id": "nicola-rennie",
+        "email": "nrennie.research@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "ggflowchart",
+    "title": "Flowcharts with 'ggplot2'",
+    "description": "Flowcharts can be a useful way to visualise complex processes. This package uses the layered grammar of graphics of 'ggplot2' to create simple flowcharts.",
+    "repo_url": "https://github.com/nrennie/ggflowchart",
+    "pkdown_url": "https://nrennie.github.io/ggflowchart/",
+    "bug_reports_url": "https://github.com/nrennie/ggflowchart/issues",
+    "logo_url": "https://nrennie.github.io/ggflowchart/logo.png",
+    "last_updated": "2023-12-20",
+    "authors": [
+      {
+        "name": "Nicola Rennie",
+        "roles": [
+          "aut",
+          "cre",
+          "cph"
+        ],
+        "directory_id": "nicola-rennie",
+        "email": "nrennie35@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "ggPMX",
+    "title": "'ggplot2' Based Tool to Facilitate Diagnostic Plots for NLME\nModels",
+    "description": "At Novartis, we aimed at standardizing the set of diagnostic plots used for modeling activities in order to reduce the overall effort required for generating such plots. For this, we developed a guidance that proposes an adequate set of diagnostics and a toolbox, called 'ggPMX' to execute them. 'ggPMX' is a toolbox that can generate all diagnostic plots at a quality sufficient for publication and submissions using few lines of code. This package focuses on plots recommended by ISoP <doi:10.1002/psp4.12161>. While not required, you can get/install the 'R' 'lixoftConnectors' package in the 'Monolix' installation, as described at the following url <https://monolixsuite.slp-software.com/r-functions/2024R1/installation-and-initialization>. When 'lixoftConnectors' is available, 'R' can use 'Monolix' directly to create the required Chart Data instead of exporting it from the 'Monolix' gui.",
+    "repo_url": "https://github.com/ggPMXdevelopment/ggPMX",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/ggPMXdevelopment/ggPMX/issues",
+    "logo_url": {},
+    "last_updated": "2025-09-05",
+    "authors": [
+      {
+        "name": "Amine Gassem",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Bruno Bieth",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Irina Baltcheva",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Thomas Dumortier",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Christian Bartels",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Souvik Bhattacharya",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Inga Ludwig",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Ines Paule",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Didier Renard",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Matthew Fidler",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0001-8538-6691"
+      },
+      {
+        "name": "Seid Hamzic",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Benjamin Guiastrennec",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Kyle T Baron",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0001-7252-5656"
+      },
+      {
+        "name": "Qing Xi Ooi",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Aleksandr Pogodaev",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-1371-207X",
+        "email": "alex.pogodaev@novartis.com"
+      },
+      {
+        "name": "Danielle Navarro",
+        "roles": [
+          "aut"
+        ],
+        "directory_id": "danielle-navarro"
+      },
+      {
+        "name": "Ibtissem Rebai",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Mahmoud Ali",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Novartis Pharma AG",
+        "roles": [
+          "cph"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ghclass",
+    "title": "Tools for Managing Classes on GitHub",
+    "description": "Interface for the GitHub API that enables efficient management of courses on GitHub. It has a functionality for managing organizations, teams, repositories, and users on GitHub and helps automate most of the tedious and repetitive tasks around creating and distributing assignments.",
+    "repo_url": "https://github.com/rundel/ghclass",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/rundel/ghclass/issues",
+    "logo_url": {},
+    "last_updated": "2025-05-06",
+    "authors": [
+      {
+        "name": "Colin Rundel",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "email": "rundel@gmail.com"
+      },
+      {
+        "name": "Mine Cetinkaya-Rundel",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Therese Anders",
+        "roles": [
+          "ctb"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "glitter",
+    "title": "glitter makes SPARQL",
+    "description": "This package aims at writing and sending SPARQL queries. It makes the exploration and use of Linked Open Data (Wikidata in particular) easier for those who do not know SPARQL.",
+    "repo_url": "https://github.com/lvaudor/glitter",
+    "pkdown_url": "https://lvaudor.github.io/glitter/",
+    "bug_reports_url": "https://github.com/lvaudor/glitter/issues",
+    "logo_url": "https://lvaudor.github.io/glitter/logo.png",
+    "last_updated": "2023-12-21",
+    "authors": [
+      {
+        "name": "Lise Vaudor",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0003-1844-6425",
+        "directory_id": "lise-vaudor",
+        "email": "lise.vaudor@ens-lyon.fr"
+      },
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon"
+      }
+    ]
+  },
+  {
+    "name": "gtreg",
+    "title": "Regulatory Tables for Clinical Research",
+    "description": "Creates tables suitable for regulatory agency submission by leveraging the 'gtsummary' package as the back end. Tables can be exported to HTML, Word, PDF and more. Highly customized outputs are available by utilizing existing styling functions from 'gtsummary' as well as custom options designed for regulatory tables.",
+    "repo_url": "https://github.com/shannonpileggi/gtreg",
+    "pkdown_url": "https://shannonpileggi.github.io/gtreg/",
+    "bug_reports_url": "https://github.com/shannonpileggi/gtreg/issues",
+    "logo_url": "https://shannonpileggi.github.io/gtreg/logo.png",
+    "last_updated": "2025-11-25",
+    "authors": [
+      {
+        "name": "Shannon Pileggi",
+        "roles": [
+          "aut",
+          "cre",
+          "cph"
+        ],
+        "orcid": "0000-0002-7732-4164",
+        "directory_id": "shannon-pileggi",
+        "email": "shannon.pileggi@gmail.com"
+      },
+      {
+        "name": "Daniel D. Sjoberg",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-0862-2018"
+      }
+    ]
+  },
+  {
+    "name": "hellodatascience",
+    "title": "Datasets from the Hello Data Science Book",
+    "description": "Provides datasets used for analysis and visualizations in the open-access Hello Data Science book.",
+    "repo_url": "https://github.com/hellodata-science/hellodatascience",
+    "pkdown_url": "https://hellodata-science.github.io/hellodatascience/",
+    "bug_reports_url": "https://github.com/hellodata-science/hellodatascience/issues",
+    "logo_url": "https://hellodata-science.github.io/hellodatascience/logo.png",
+    "last_updated": "2026-01-19",
+    "authors": [
+      {
+        "name": "Mine Dogucu",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-8007-934X",
+        "directory_id": "mine-dogucu",
+        "email": "mdogucu@gmail.com"
+      },
+      {
+        "name": "Catalina Medina",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-2847-8180"
+      },
+      {
+        "name": "Alma Castro",
+        "roles": [
+          "aut"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "hexify",
+    "title": "Create Hex Stickers",
+    "description": "Allows the user to create hex stickers from images.",
+    "repo_url": "https://github.com/djnavarro/hexify",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/djnavarro/hexify/issues",
+    "logo_url": {},
+    "last_updated": "2022-02-02",
+    "authors": [
+      {
+        "name": "Danielle Navarro",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-7648-6578",
+        "directory_id": "danielle-navarro",
+        "email": "djnavarro@protonmail.com"
+      }
+    ]
+  },
+  {
+    "name": "hmsidwR",
+    "title": "Health Metrics and the Spread of Infectious Diseases",
+    "description": "A collection of datasets and supporting functions accompanying Health Metrics and the Spread of Infectious Diseases by Federica Gazzelloni (2024). This package provides data for health metrics calculations, including Disability-Adjusted Life Years (DALYs), Years of Life Lost (YLLs), and Years Lived with Disability (YLDs), as well as additional tools for analyzing and visualizing health data. Federica Gazzelloni (2024) <doi:10.5281/zenodo.10818338>.",
+    "repo_url": "https://github.com/Fgazzelloni/hmsidwR",
+    "pkdown_url": "https://fgazzelloni.github.io/hmsidwR/",
+    "bug_reports_url": "https://github.com/Fgazzelloni/hmsidwR/issues",
+    "logo_url": "https://fgazzelloni.github.io/hmsidwR/logo.png",
+    "last_updated": "2025-05-16",
+    "authors": [
+      {
+        "name": "Federica Gazzelloni",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-4285-611X",
+        "directory_id": "federica-gazzelloni",
+        "email": "fede.gazzelloni@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "igraph",
+    "title": "Network Analysis and Visualization",
+    "description": "Routines for simple graphs and network analysis. It can handle large graphs very well and provides functions for generating random and regular graphs, graph visualization, centrality methods and much more.",
+    "repo_url": "https://github.com/igraph/rigraph",
+    "pkdown_url": "https://r.igraph.org/",
+    "bug_reports_url": "https://github.com/igraph/rigraph/issues",
+    "logo_url": "https://r.igraph.org/logo.png",
+    "last_updated": "2026-05-04",
+    "authors": [
+      {
+        "name": "Gábor Csárdi",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0001-7098-9676"
+      },
+      {
+        "name": "Tamás Nepusz",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-1451-338X"
+      },
+      {
+        "name": "Vincent Traag",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-3170-3879"
+      },
+      {
+        "name": "Szabolcs Horvát",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-3100-523X"
+      },
+      {
+        "name": "Fabio Zanini",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0001-7097-8539"
+      },
+      {
+        "name": "Daniel Noom",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Kirill Müller",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-1416-3412",
+        "email": "kirill@cynkra.com"
+      },
+      {
+        "name": "Michael Antonov",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Chan Zuckerberg Initiative",
+        "roles": [
+          "fnd"
+        ]
+      },
+      {
+        "name": "David Schoch",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-2952-4812"
+      },
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon"
+      },
+      {
+        "name": "R Consortium",
+        "roles": [
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "infer",
+    "title": "Tidy Statistical Inference",
+    "description": "The objective of this package is to perform inference using an expressive statistical grammar that coheres with the tidy design framework.",
+    "repo_url": "https://github.com/tidymodels/infer",
+    "pkdown_url": "https://infer.tidymodels.org/",
+    "bug_reports_url": "https://github.com/tidymodels/infer/issues",
+    "logo_url": "https://infer.tidymodels.org/logo.png",
+    "last_updated": "2025-12-18",
+    "authors": [
+      {
+        "name": "Andrew Bray",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Chester Ismay",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-2820-2547"
+      },
+      {
+        "name": "Evgeni Chasnovski",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-1617-4019"
+      },
+      {
+        "name": "Simon Couch",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-5676-5107",
+        "email": "simon.couch@posit.co"
+      },
+      {
+        "name": "Ben Baumer",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-3279-0516"
+      },
+      {
+        "name": "Mine Cetinkaya-Rundel",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0001-6452-2420"
+      },
+      {
+        "name": "Ted Laderas",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-6207-7068"
+      },
+      {
+        "name": "Nick Solomon",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Johanna Hardin",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Albert Y. Kim",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0001-7824-306X"
+      },
+      {
+        "name": "Neal Fultz",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Doug Friedman",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Richie Cotton",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0003-2504-802X"
+      },
+      {
+        "name": "Brian Fannin",
+        "roles": [
+          "ctb"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "janeaustenr",
+    "title": "Jane Austen's Complete Novels",
+    "description": "Full texts for Jane Austen's 6 completed novels, ready for text analysis. These novels are \"Sense and Sensibility\", \"Pride and Prejudice\", \"Mansfield Park\", \"Emma\", \"Northanger Abbey\", and \"Persuasion\".",
+    "repo_url": "https://github.com/juliasilge/janeaustenr",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/juliasilge/janeaustenr/issues",
+    "logo_url": {},
+    "last_updated": "2022-08-26",
+    "authors": [
+      {
+        "name": "Julia Silge",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-3671-836X",
+        "directory_id": "julia-silge",
+        "email": "julia.silge@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "jasmines",
+    "title": "Generative Art",
+    "description": "It doesn't do much, really.",
+    "repo_url": "https://github.com/djnavarro/jasmines",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/djnavarro/jasmines/issues",
+    "logo_url": {},
+    "last_updated": "2021-04-07",
+    "authors": [
+      {
+        "name": "Danielle Navarro",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-7648-6578",
+        "directory_id": "danielle-navarro",
+        "email": "d.navarro@unsw.edu.au"
+      }
+    ]
+  },
+  {
+    "name": "jaysire",
+    "title": "Build jsPsych Experiments in R",
+    "description": "The jaysire package allows the user to build browser based behavioral experiments within R by providing an interface to the jsPsych javascript library.",
+    "repo_url": "https://github.com/djnavarro/jaysire",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/djnavarro/jaysire/issues",
+    "logo_url": {},
+    "last_updated": "2021-04-07",
+    "authors": [
+      {
+        "name": "Danielle Navarro",
+        "directory_id": "danielle-navarro",
+        "email": "d.navarro@unsw.edu.au"
+      },
+      {
+        "name": "Danielle Navarro",
+        "roles": [
+          "cre"
+        ],
+        "directory_id": "danielle-navarro",
+        "email": "d.navarro@unsw.edu.au"
+      }
+    ]
+  },
+  {
+    "name": "learnres",
+    "title": "Templates for different learnr tutorials in Spanish",
+    "description": "Contains templates and themeing files.",
+    "repo_url": "https://github.com/yabellini/learnres",
+    "pkdown_url": {},
+    "bug_reports_url": {},
+    "logo_url": {},
+    "last_updated": "2021-07-19",
+    "authors": [
+      {
+        "name": "Yanina Bellini Saibene",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0000-0000-0000",
+        "directory_id": "yanina-bellini-saibene",
+        "email": "yabellini@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "LITAP",
+    "title": "Landscape Integrated Terrain Analysis Package",
+    "description": "Terrain analysis and landscape and hydrology models built on terrain attributes. A major component of LITAP is founded on R. A. (Bob) MacMillan's LandMapR suite of programs for flow topology and landform segmentation analyses with extended new parameters and methodologies, as well as with new calculations and uses of directional terrain attributes.",
+    "repo_url": "https://github.com/FRDC-SHL/LITAP",
+    "pkdown_url": {},
+    "bug_reports_url": {},
+    "logo_url": {},
+    "last_updated": "2024-10-02",
+    "authors": [
+      {
+        "name": "Steffi LaZerte",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "directory_id": "steffi-lazerte",
+        "email": "steffi@steffi.ca"
+      },
+      {
+        "name": "Sheng Li",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Agriculture and Agri-Food Canada",
+        "roles": [
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "lsr",
+    "title": "Companion to \"Learning Statistics with R\"",
+    "description": "A collection of tools intended to make introductory statistics easier to teach, including wrappers for common hypothesis tests and basic data manipulation. It accompanies Navarro, D. J. (2015). Learning Statistics with R: A Tutorial for Psychology Students and Other Beginners, Version 0.6.",
+    "repo_url": "https://github.com/djnavarro/lsr",
+    "pkdown_url": "http://lsr.djnavarro.net/",
+    "bug_reports_url": "https://github.com/djnavarro/lsr/issues",
+    "logo_url": {},
+    "last_updated": "2026-03-21",
+    "authors": [
+      {
+        "name": "Danielle Navarro",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-7648-6578",
+        "directory_id": "danielle-navarro",
+        "email": "djnavarro@protonmail.com"
+      }
+    ]
+  },
+  {
     "name": "meetupr",
-    "description": "Provides programmatic access to the 'Meetup' 'GraphQL' API ",
+    "title": "Access Meetup Data",
+    "description": "Provides programmatic access to the 'Meetup' 'GraphQL' API (<https://www.meetup.com/graphql/>), enabling users to retrieve information about groups, events, and members from 'Meetup' (<https://www.meetup.com/>). Supports authentication via 'OAuth2' and includes functions for common queries and data manipulation tasks.",
     "repo_url": "https://github.com/rladies/meetupr",
     "pkdown_url": "https://rladies.org/meetupr/",
+    "bug_reports_url": "https://github.com/rladies/meetupr/issues",
     "logo_url": "https://rladies.org/meetupr/logo.png",
-    "maintainers": [
+    "last_updated": "2025-12-23",
+    "authors": [
+      {
+        "name": "Athanasia Mo Mowinckel",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-5756-0223",
+        "directory_id": "athanasia-mo-mowinckel",
+        "email": "a.m.mowinckel@psykologi.uio.no"
+      },
+      {
+        "name": "Erin LeDell",
+        "roles": [
+          "aut"
+        ],
+        "directory_id": "erin-ledell"
+      },
+      {
+        "name": "Olga Mierzwa-Sulima",
+        "roles": [
+          "aut"
+        ],
+        "directory_id": "olga-mierzwasulima"
+      },
+      {
+        "name": "Lucy D'Agostino McGowan",
+        "roles": [
+          "aut"
+        ],
+        "directory_id": "lucy-dagostino-mcgowan"
+      },
+      {
+        "name": "Claudia Vitolo",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Gabriela De Queiroz",
+        "roles": [
+          "ctb"
+        ],
+        "directory_id": "gabriela-de-queiroz"
+      },
+      {
+        "name": "Michael Beigelmacher",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Augustina Ragwitz",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Greg Sutcliffe",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Rick Pack",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Ben Ubah",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon"
+      },
+      {
+        "name": "Barret Schloerke",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0001-9986-114X"
+      },
       {
         "name": "R-Ladies Global",
-        "email": "info@rladies.org",
-        "social_media": {
-          "bluesky": "rladies.org",
-          "github": "rladies",
-          "mastodon": "@RLadiesGlobal@hachyderm.io"
-        }
+        "roles": [
+          "cph"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "messy",
+    "title": "Create Messy Data from Clean Data Frames",
+    "description": "For the purposes of teaching, it is often desirable to show examples of working with messy data and how to clean it. This R package creates messy data from clean, tidy data frames so that students have a clean example to work towards.",
+    "repo_url": "https://github.com/nrennie/messy",
+    "pkdown_url": "https://nrennie.rbind.io/messy/",
+    "bug_reports_url": "https://github.com/nrennie/messy/issues",
+    "logo_url": "https://nrennie.rbind.io/messy/logo.png",
+    "last_updated": "2025-08-29",
+    "authors": [
+      {
+        "name": "Nicola Rennie",
+        "roles": [
+          "aut",
+          "cre",
+          "cph"
+        ],
+        "orcid": "0000-0003-4797-557X",
+        "directory_id": "nicola-rennie",
+        "email": "nrennie35@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "MLDataR",
+    "title": "Collection of Machine Learning Datasets for Supervised Machine\nLearning",
+    "description": "Contains a collection of datasets for working with machine learning tasks. It will contain datasets for supervised machine learning Jiang (2020)<doi:10.1016/j.beth.2020.05.002> and will include datasets for classification and regression. The aim of this package is to use data generated around health and other domains.",
+    "repo_url": "https://github.com/StatsGary/MLDataR",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/StatsGary/MLDataR/issues",
+    "logo_url": {},
+    "last_updated": "2022-10-03",
+    "authors": [
+      {
+        "name": "Gary Hutson",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0003-3534-6143",
+        "email": "hutsons-hacks@outlook.com"
+      },
+      {
+        "name": "Asif Laldin",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Isabella Velásquez",
+        "roles": [
+          "aut"
+        ],
+        "directory_id": "isabella-velasquez"
+      }
+    ]
+  },
+  {
+    "name": "monochromeR",
+    "title": "Easily Create, View and Use Monochrome Colour Palettes",
+    "description": "Generate a monochrome palette from a starting colour for a specified number of colours. The package can also be used to display colour palettes in the plot window, with or without hex codes and colour labels.",
+    "repo_url": "https://github.com/cararthompson/monochromeR",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/cararthompson/monochromeR/issues",
+    "logo_url": {},
+    "last_updated": "2023-09-05",
+    "authors": [
+      {
+        "name": "Cara Thompson",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-6472-5073",
+        "email": "packages@cararthompson.com"
+      }
+    ]
+  },
+  {
+    "name": "MSUthemes",
+    "title": "Michigan State University (MSU) Palettes and Themes",
+    "description": "Defines colour palettes and themes for Michigan State University (MSU) publications and presentations. Palettes and themes are supported in both base R and 'ggplot2' graphics, and are intended to provide consistency between those creating documents and presentations.",
+    "repo_url": "https://github.com/emilioxavier/MSUthemes",
+    "pkdown_url": "https://emilioxavier.github.io/MSUthemes/",
+    "bug_reports_url": "https://github.com/emilioxavier/MSUthemes/issues",
+    "logo_url": "https://emilioxavier.github.io/MSUthemes/logo.png",
+    "last_updated": "2025-10-17",
+    "authors": [
+      {
+        "name": "Emilio Xavier Esposito",
+        "roles": [
+          "aut",
+          "cre",
+          "cph"
+        ],
+        "orcid": "0000-0002-6193-0485",
+        "email": "emilio.esposito@gmail.com"
+      },
+      {
+        "name": "Nicola Rennie",
+        "roles": [
+          "aut"
+        ],
+        "directory_id": "nicola-rennie"
+      },
+      {
+        "name": "Michigan State University",
+        "roles": [
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "namer",
+    "title": "Names Your 'R Markdown' Chunks",
+    "description": "It names the 'R Markdown' chunks of files based on the filename.",
+    "repo_url": "https://github.com/jumpingrivers/namer",
+    "pkdown_url": "https://jumpingrivers.github.io/namer/",
+    "bug_reports_url": "https://github.com/jumpingrivers/namer/issues",
+    "logo_url": {},
+    "last_updated": "2025-01-23",
+    "authors": [
+      {
+        "name": "Colin Gillespie",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "email": "colin@jumpingrivers.com"
+      },
+      {
+        "name": "Steph Locke",
+        "roles": [
+          "aut"
+        ],
+        "directory_id": "steph-locke"
+      },
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon"
+      },
+      {
+        "name": "Ellis Valentiner",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Charlie Hadley",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-3039-6849"
+      },
+      {
+        "name": "Jumping Rivers",
+        "roles": [
+          "fnd"
+        ]
+      },
+      {
+        "name": "Han Oostdijk",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0001-6710-4566"
+      },
+      {
+        "name": "Patrick Schratz",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0003-0748-6624"
+      }
+    ]
+  },
+  {
+    "name": "naturecounts",
+    "title": "Access and download data on plant and animal populations from\nNatureCounts",
+    "description": "Access and download data on plant and animal populations from various databases through NatureCounts, a service managed by Bird Studies Canada.",
+    "repo_url": "https://github.com/BirdsCanada/naturecounts",
+    "pkdown_url": "https://naturecounts.ca",
+    "bug_reports_url": {},
+    "logo_url": {},
+    "last_updated": "2026-03-31",
+    "authors": [
+      {
+        "name": "Steffi LaZerte",
+        "roles": [
+          "aut"
+        ],
+        "directory_id": "steffi-lazerte"
+      },
+      {
+        "name": "Denis Lepage",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "email": "dlepage@birdscanada.org"
+      }
+    ]
+  },
+  {
+    "name": "odbr",
+    "title": "Download Data from Brazil's Origin Destination Surveys",
+    "description": "Download data from Brazil's Origin Destination Surveys. The package covers both data from household travel surveys, dictionaries of variables, and the spatial geometries of surveys conducted in different years and across various urban areas in Brazil. For some cities, the package will include enhanced versions of the data sets with variables \"harmonized\" across different years.",
+    "repo_url": "https://github.com/hsvab/odbr",
+    "pkdown_url": "https://hsvab.github.io/odbr/",
+    "bug_reports_url": "https://github.com/hsvab/odbr/issues",
+    "logo_url": "https://hsvab.github.io/odbr/logo.png",
+    "last_updated": "2025-02-14",
+    "authors": [
+      {
+        "name": "Haydee Svab",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "directory_id": "haydee-svab",
+        "email": "hsvab@hsvab.eng.br"
+      },
+      {
+        "name": "Beatriz Milz",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-3064-4486",
+        "directory_id": "beatriz-milz"
+      },
+      {
+        "name": "Diego Rabatone Oliveira",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Rafael H. M. Pereira",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-2125-7465"
+      }
+    ]
+  },
+  {
+    "name": "opencage",
+    "title": "Geocode with the OpenCage API",
+    "description": "Geocode with the OpenCage API, either from place name to longitude and latitude (forward geocoding) or from longitude and latitude to the name and address of a location (reverse geocoding), see <https://opencagedata.com/>.",
+    "repo_url": "https://github.com/ropensci/opencage",
+    "pkdown_url": "https://docs.ropensci.org/opencage/",
+    "bug_reports_url": "https://github.com/ropensci/opencage/issues",
+    "logo_url": "https://docs.ropensci.org/opencage/logo.png",
+    "last_updated": "2021-02-20",
+    "authors": [
+      {
+        "name": "Daniel Possenriede",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-6738-9845",
+        "email": "possenriede+r@gmail.com"
+      },
+      {
+        "name": "Jesse Sadler",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0001-6081-9681"
+      },
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon"
+      },
+      {
+        "name": "Noam Ross",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Jake Russ",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Julia Silge",
+        "roles": [
+          "rev"
+        ],
+        "directory_id": "julia-silge"
+      }
+    ]
+  },
+  {
+    "name": "openintro",
+    "title": "Datasets and Supplemental Functions from 'OpenIntro' Textbooks\nand Labs",
+    "description": "Supplemental functions and data for 'OpenIntro' resources, which includes open-source textbooks and resources for introductory statistics (<https://www.openintro.org/>). The package contains datasets used in our open-source textbooks along with custom plotting functions for reproducing book figures. Note that many functions and examples include color transparency; some plotting elements may not show up properly (or at all) when run in some versions of Windows operating system.",
+    "repo_url": "https://github.com/OpenIntroStat/openintro/",
+    "pkdown_url": "http://openintrostat.github.io/openintro/",
+    "bug_reports_url": "https://github.com/OpenIntroStat/openintro/issues",
+    "logo_url": "http://openintrostat.github.io/openintro/logo.png",
+    "last_updated": "2024-05-31",
+    "authors": [
+      {
+        "name": "Mine Çetinkaya-Rundel",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-6452-2420",
+        "email": "cetinkaya.mine@gmail.com"
+      },
+      {
+        "name": "David Diez",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Andrew Bray",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Albert Y. Kim",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0001-7824-306X"
+      },
+      {
+        "name": "Ben Baumer",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Chester Ismay",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Nick Paterno",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Christopher Barr",
+        "roles": [
+          "aut"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "osmdata",
+    "title": "Import 'OpenStreetMap' Data as Simple Features or Spatial\nObjects",
+    "description": "Download and import of 'OpenStreetMap' ('OSM') data as 'sf' or 'sp' objects. 'OSM' data are extracted from the 'Overpass' web server (<https://overpass-api.de/>) and processed with very fast 'C++' routines for return to 'R'.",
+    "repo_url": "https://github.com/ropensci/osmdata",
+    "pkdown_url": "https://docs.ropensci.org/osmdata/",
+    "bug_reports_url": "https://github.com/ropensci/osmdata/issues",
+    "logo_url": "https://docs.ropensci.org/osmdata/logo.png",
+    "last_updated": "2025-08-23",
+    "authors": [
+      {
+        "name": "Joan Maspons",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0003-2286-8727",
+        "email": "joanmaspons@gmail.com"
+      },
+      {
+        "name": "Mark Padgham",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Bob Rudis",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Robin Lovelace",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "aut"
+        ],
+        "directory_id": "maelle-salmon"
+      },
+      {
+        "name": "Andrew Smith",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "James Smith",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Andrea Gilardi",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Enrico Spinielli",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Anthony North",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Martin Machyna",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Marcin Kalicinski",
+        "roles": [
+          "ctb",
+          "cph"
+        ]
+      },
+      {
+        "name": "Eli Pousson",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0001-8280-1706"
+      }
+    ]
+  },
+  {
+    "name": "overviewR",
+    "title": "Easily Extracting Information About Your Data",
+    "description": "Makes it easy to display descriptive information on a data set. Getting an easy overview of a data set by displaying and visualizing sample information in different tables (e.g., time and scope conditions). The package also provides publishable 'LaTeX' code to present the sample information.",
+    "repo_url": "https://github.com/cosimameyer/overviewR",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/cosimameyer/overviewR/issues",
+    "logo_url": {},
+    "last_updated": "2026-05-04",
+    "authors": [
+      {
+        "name": "Cosima Meyer",
+        "roles": [
+          "cre",
+          "aut"
+        ],
+        "directory_id": "cosima-meyer",
+        "email": "cosima.meyer@gmail.com"
+      },
+      {
+        "name": "Dennis Hammerschmidt",
+        "roles": [
+          "aut"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "palmerpenguins",
+    "title": "Palmer Archipelago (Antarctica) Penguin Data",
+    "description": "Size measurements, clutch observations, and blood isotope ratios for adult foraging Adélie, Chinstrap, and Gentoo penguins observed on islands in the Palmer Archipelago near Palmer Station, Antarctica. Data were collected and made available by Dr. Kristen Gorman and the Palmer Station Long Term Ecological Research (LTER) Program.",
+    "repo_url": "https://github.com/allisonhorst/palmerpenguins",
+    "pkdown_url": "https://allisonhorst.github.io/palmerpenguins/",
+    "bug_reports_url": "https://github.com/allisonhorst/palmerpenguins/issues",
+    "logo_url": "https://allisonhorst.github.io/palmerpenguins/logo.png",
+    "last_updated": "2022-08-15",
+    "authors": [
+      {
+        "name": "Allison Horst",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-6047-5564",
+        "email": "ahorst@ucsb.edu"
+      },
+      {
+        "name": "Alison Hill",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-8082-1890"
+      },
+      {
+        "name": "Kristen Gorman",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-0258-9264"
+      }
+    ]
+  },
+  {
+    "name": "parmsurvfit",
+    "title": "Parametric Models for Survival Data",
+    "description": "Executes simple parametric models for right-censored survival data. Functionality emulates capabilities in 'Minitab', including fitting right-censored data, assessing fit, plotting survival functions, and summary statistics and probabilities.",
+    "repo_url": "https://github.com/apjacobson/parmsurvfit",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/apjacobson/parmsurvfit/issues",
+    "logo_url": {},
+    "last_updated": "2018-12-07",
+    "authors": [
+      {
+        "name": "Ashley Jacobson",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "email": "ashleypjacobson@gmail.com"
+      },
+      {
+        "name": "Victor Wilson",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Shannon Pileggi",
+        "roles": [
+          "aut"
+        ],
+        "directory_id": "shannon-pileggi"
+      }
+    ]
+  },
+  {
+    "name": "pins",
+    "title": "Pin, Discover, and Share Resources",
+    "description": "Publish data sets, models, and other R objects, making it easy to share them across projects and with your colleagues. You can pin objects to a variety of \"boards\", including local folders (to share on a networked drive or with 'DropBox'), 'Posit Connect', 'AWS S3', and more.",
+    "repo_url": "https://github.com/rstudio/pins-r",
+    "pkdown_url": "https://pins.rstudio.com/",
+    "bug_reports_url": "https://github.com/rstudio/pins-r/issues",
+    "logo_url": "https://pins.rstudio.com/logo.png",
+    "last_updated": "2026-03-09",
+    "authors": [
+      {
+        "name": "Julia Silge",
+        "roles": [
+          "cre",
+          "aut"
+        ],
+        "orcid": "0000-0002-3671-836X",
+        "directory_id": "julia-silge",
+        "email": "julia.silge@posit.co"
+      },
+      {
+        "name": "Hadley Wickham",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-4757-117X"
+      },
+      {
+        "name": "Javier Luraschi",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Posit Software"
+      },
+      {
+        "name": "PBC",
+        "roles": [
+          "cph",
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pkgdown",
+    "title": "Make Static HTML Documentation for a Package",
+    "description": "Generate an attractive and useful website from a source package. 'pkgdown' converts your documentation, vignettes, 'README', and more to 'HTML' making it easy to share information about your package online.",
+    "repo_url": "https://github.com/r-lib/pkgdown",
+    "pkdown_url": "https://pkgdown.r-lib.org/",
+    "bug_reports_url": "https://github.com/r-lib/pkgdown/issues",
+    "logo_url": "https://pkgdown.r-lib.org/logo.png",
+    "last_updated": "2025-11-06",
+    "authors": [
+      {
+        "name": "Hadley Wickham",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0003-4757-117X",
+        "email": "hadley@posit.co"
+      },
+      {
+        "name": "Jay Hesselberth",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-6299-179X"
+      },
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon"
+      },
+      {
+        "name": "Olivier Roy",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Salim Brüggemann",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-5329-5987"
+      },
+      {
+        "name": "Posit Software"
+      },
+      {
+        "name": "PBC",
+        "roles": [
+          "cph",
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pkgsearch",
+    "title": "Search and Query CRAN R Packages",
+    "description": "Search CRAN metadata about packages by keyword, popularity, recent activity, package name and more. Uses the 'R-hub' search server, see <https://r-pkg.org> and the CRAN metadata database, that contains information about CRAN packages. Note that this is _not_ a CRAN project.",
+    "repo_url": "https://github.com/r-hub/pkgsearch",
+    "pkdown_url": "https://r-hub.github.io/pkgsearch/",
+    "bug_reports_url": "https://github.com/r-hub/pkgsearch/issues",
+    "logo_url": {},
+    "last_updated": "2025-04-12",
+    "authors": [
+      {
+        "name": "Gábor Csárdi",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "email": "csardi.gabor@gmail.com"
+      },
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon"
+      },
+      {
+        "name": "R Consortium",
+        "roles": [
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pregnancy",
+    "title": "Calculate and Track Dates and Medications During Pregnancy",
+    "description": "Provides functionality for calculating pregnancy-related dates and tracking medications during pregnancy and fertility treatment. Calculates due dates from various starting points including last menstrual period and IVF (In Vitro Fertilisation) transfer dates, determines pregnancy progress on any given date, and identifies when specific pregnancy weeks are reached. Includes medication tracking capabilities for individuals undergoing fertility treatment or during pregnancy, allowing users to monitor remaining doses and quantities needed over specified time periods. Designed for those tracking their own pregnancies or supporting partners through the process, making use of options to personalise output messages. For details on due date calculations, see <https://www.acog.org/clinical/clinical-guidance/committee-opinion/articles/2017/05/methods-for-estimating-the-due-date>.",
+    "repo_url": "https://github.com/EllaKaye/pregnancy",
+    "pkdown_url": "https://ellakaye.github.io/pregnancy/",
+    "bug_reports_url": "https://github.com/EllaKaye/pregnancy/issues",
+    "logo_url": "https://ellakaye.github.io/pregnancy/logo.png",
+    "last_updated": "2026-01-15",
+    "authors": [
+      {
+        "name": "Ella Kaye",
+        "roles": [
+          "aut",
+          "cre",
+          "cph"
+        ],
+        "orcid": "0000-0002-7300-3718",
+        "directory_id": "ella-kaye",
+        "email": "ella.kaye@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "PrettyCols",
+    "title": "Pretty Colour Palettes",
+    "description": "Defines aesthetically pleasing colour palettes.",
+    "repo_url": "https://github.com/nrennie/PrettyCols",
+    "pkdown_url": "https://nrennie.rbind.io/PrettyCols/",
+    "bug_reports_url": "https://github.com/nrennie/PrettyCols/issues",
+    "logo_url": "https://nrennie.rbind.io/PrettyCols/logo.png",
+    "last_updated": "2025-04-23",
+    "authors": [
+      {
+        "name": "Nicola Rennie",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "directory_id": "nicola-rennie",
+        "email": "nrennie35@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "projmgr",
+    "title": "Task Tracking and Project Management with GitHub",
+    "description": "Provides programmatic access to 'GitHub' API with a focus on project management. Key functionality includes setting up issues and milestones from R objects or 'YAML' configurations, querying outstanding or completed tasks, and generating progress updates in tables, charts, and RMarkdown reports. Useful for those using 'GitHub' in personal, professional, or academic settings with an emphasis on streamlining the workflow of data analysis projects.",
+    "repo_url": "https://github.com/emilyriederer/projmgr",
+    "pkdown_url": "https://emilyriederer.github.io/projmgr/",
+    "bug_reports_url": "https://github.com/emilyriederer/projmgr/issues",
+    "logo_url": "https://emilyriederer.github.io/projmgr/logo.png",
+    "last_updated": "2025-11-29",
+    "authors": [
+      {
+        "name": "Emily Riederer",
+        "roles": [
+          "cre",
+          "aut"
+        ],
+        "directory_id": "emily-riederer",
+        "email": "emilyriederer@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "quadkeyr",
+    "title": "Generate Raster Images from QuadKey-Identified Datasets",
+    "description": "A set of functions of increasing complexity allows users to (1) convert QuadKey-identified datasets, based on 'Microsoft's Bing Maps Tile System', into Simple Features data frames, (2) transform Simple Features data frames into rasters, and (3) process multiple 'Meta' ('Facebook') QuadKey-identified human mobility files directly into raster files. For more details, see D’Andrea et al. (2024) <doi:10.21105/joss.06500>.",
+    "repo_url": "https://github.com/ropensci/quadkeyr",
+    "pkdown_url": "https://docs.ropensci.org/quadkeyr/",
+    "bug_reports_url": "https://github.com/ropensci/quadkeyr/issues",
+    "logo_url": "https://docs.ropensci.org/quadkeyr/logo.png",
+    "last_updated": "2025-03-24",
+    "authors": [
+      {
+        "name": "Florencia D'Andrea",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-0041-097X",
+        "directory_id": "florencia-dandrea",
+        "email": "florencia.dandrea@gmail.com"
+      },
+      {
+        "name": "Pilar Fernandez",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0001-8645-2267",
+        "directory_id": "pilar-fernandez"
+      },
+      {
+        "name": "Maria Paula Caldas",
+        "roles": [
+          "rev"
+        ],
+        "orcid": "0000-0002-1938-6471",
+        "directory_id": "maria-paula-caldas"
+      },
+      {
+        "name": "Vincent van Hees",
+        "roles": [
+          "rev"
+        ],
+        "orcid": "0000-0003-0182-9008"
+      },
+      {
+        "name": "Andrew Pulsipher",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-0773-3210"
+      },
+      {
+        "name": "CDC's Center for Forecasting and Outbreak Analytics",
+        "roles": [
+          "fnd"
+        ]
+      },
+      {
+        "name": "MIDAS-NIH COVID-19 urgent grant program",
+        "roles": [
+          "fnd"
+        ]
+      },
+      {
+        "name": "Paul G. Allen School for Global Health"
+      },
+      {
+        "name": "Washington State University",
+        "roles": [
+          "cph"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "qualtRics",
+    "title": "Download 'Qualtrics' Survey Data",
+    "description": "Provides functions to access survey results directly into R using the 'Qualtrics' API. 'Qualtrics' <https://www.qualtrics.com/about/> is an online survey and data collection software platform. See <https://api.qualtrics.com/> for more information about the 'Qualtrics' API. This package is community-maintained and is not officially supported by 'Qualtrics'.",
+    "repo_url": "https://github.com/ropensci/qualtRics",
+    "pkdown_url": "https://docs.ropensci.org/qualtRics/",
+    "bug_reports_url": "https://github.com/ropensci/qualtRics/issues",
+    "logo_url": "https://docs.ropensci.org/qualtRics/logo.png",
+    "last_updated": "2025-08-23",
+    "authors": [
+      {
+        "name": "Jasper Ginn",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Jackson Curtis",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Shaun Jackson",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Samuel Kaminsky",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Eric Knudsen",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Joseph O'Brien",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Daniel Seneca",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Julia Silge",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-3671-836X",
+        "directory_id": "julia-silge",
+        "email": "julia.silge@gmail.com"
+      },
+      {
+        "name": "Phoebe Wong",
+        "roles": [
+          "ctb"
+        ],
+        "directory_id": "phoebe-wong"
+      }
+    ]
+  },
+  {
+    "name": "quartose",
+    "title": "Dynamically Generate Quarto Syntax",
+    "description": "Provides helper functions to work programmatically within a quarto document. It allows the user to create section headers, tabsets, divs, and spans, and formats these objects into quarto syntax when printed into a document.",
+    "repo_url": "https://github.com/djnavarro/quartose",
+    "pkdown_url": "https://quartose.djnavarro.net/",
+    "bug_reports_url": "https://github.com/djnavarro/quartose/issues",
+    "logo_url": {},
+    "last_updated": "2025-07-09",
+    "authors": [
+      {
+        "name": "Danielle Navarro",
+        "roles": [
+          "aut",
+          "cre",
+          "cph"
+        ],
+        "directory_id": "danielle-navarro",
+        "email": "djnavarro@protonmail.com"
+      }
+    ]
+  },
+  {
+    "name": "queue",
+    "title": "Simple Multi-Threaded Task Queuing",
+    "description": "Implements a simple multi-threaded task queue using R6 classes.",
+    "repo_url": "https://github.com/djnavarro/queue",
+    "pkdown_url": "http://djnavarro.net/queue/",
+    "bug_reports_url": "https://github.com/djnavarro/queue/issues",
+    "logo_url": {},
+    "last_updated": "2026-03-21",
+    "authors": [
+      {
+        "name": "Danielle Navarro",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-7648-6578",
+        "directory_id": "danielle-navarro",
+        "email": "djnavarro@protonmail.com"
+      }
+    ]
+  },
+  {
+    "name": "rainbowr",
+    "title": "Make LGBT Hexes and Flags",
+    "description": "Generates a variety of LGBT flags (e.g., rainbow, transgender) overlaid with the R logo, using the magick package. Also generates hex stickers based on LGBT flags and tilings thereof.",
+    "repo_url": "https://github.com/djnavarro/rainbowr",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/djnavarro/rainbowr/issues",
+    "logo_url": {},
+    "last_updated": "2020-07-07",
+    "authors": [
+      {
+        "name": "Danielle Navarro",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-7648-6578",
+        "directory_id": "danielle-navarro",
+        "email": "d.navarro@unsw.edu.au"
+      }
+    ]
+  },
+  {
+    "name": "rhub",
+    "title": "Tools for R Package Developers",
+    "description": "R-hub v2 uses GitHub Actions to run 'R CMD check' and similar package checks. The 'rhub' package helps you set up R-hub v2 for your R package, and start running checks.",
+    "repo_url": "https://github.com/r-hub/rhub",
+    "pkdown_url": "https://r-hub.github.io/rhub/",
+    "bug_reports_url": "https://github.com/r-hub/rhub/issues",
+    "logo_url": "https://r-hub.github.io/rhub/logo.png",
+    "last_updated": "2025-03-06",
+    "authors": [
+      {
+        "name": "Gábor Csárdi",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "email": "csardi.gabor@gmail.com"
+      },
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon"
+      },
+      {
+        "name": "R Consortium",
+        "roles": [
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "riem",
+    "title": "Accesses Weather Data from the Iowa Environment Mesonet",
+    "description": "Allows to get weather data from Automated Surface Observing System (ASOS) stations (airports) in the whole world thanks to the Iowa Environment Mesonet website.",
+    "repo_url": "https://github.com/ropensci/riem",
+    "pkdown_url": "https://docs.ropensci.org/riem/",
+    "bug_reports_url": "https://github.com/ropensci/riem/issues",
+    "logo_url": "https://docs.ropensci.org/riem/logo.png",
+    "last_updated": "2025-01-31",
+    "authors": [
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon",
+        "email": "maelle.salmon@yahoo.se"
+      },
+      {
+        "name": "Brooke Anderson",
+        "roles": [
+          "rev"
+        ],
+        "directory_id": "brooke-anderson"
+      },
+      {
+        "name": "CHAI Project",
+        "roles": [
+          "fnd"
+        ]
+      },
+      {
+        "name": "rOpenSci",
+        "roles": [
+          "fnd"
+        ]
+      },
+      {
+        "name": "Daryl Herzmann",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Jonathan Elchison",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0009-0004-0787-3426"
+      }
+    ]
+  },
+  {
+    "name": "roblog",
+    "title": "rOpenSci's blog guidance",
+    "description": "It provides templates for roweb2 blogging and help for a GitHub forking workflow.",
+    "repo_url": "https://github.com/ropenscilabs/roblog",
+    "pkdown_url": "https://docs.ropensci.org/roblog/",
+    "bug_reports_url": "https://github.com/ropenscilabs/roblog/issues",
+    "logo_url": "https://docs.ropensci.org/roblog/logo.png",
+    "last_updated": "2026-02-18",
+    "authors": [
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon",
+        "email": "maelle.salmon@yahoo.se"
+      },
+      {
+        "name": "Stefanie Butland",
+        "roles": [
+          "aut"
+        ],
+        "directory_id": "stefanie-butland"
+      },
+      {
+        "name": "rOpenSci",
+        "roles": [
+          "fnd"
+        ]
+      },
+      {
+        "name": "Amanda Dobbyn",
+        "roles": [
+          "ctb"
+        ],
+        "directory_id": "amanda-dobbyn"
+      },
+      {
+        "name": "Christophe Dervieux",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Romain LESUR",
+        "roles": [
+          "ctb"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "rsample",
+    "title": "General Resampling Infrastructure",
+    "description": "Classes and functions to create and summarize different types of resampling objects (e.g. bootstrap, cross-validation).",
+    "repo_url": "https://github.com/tidymodels/rsample",
+    "pkdown_url": "https://rsample.tidymodels.org",
+    "bug_reports_url": "https://github.com/tidymodels/rsample/issues",
+    "logo_url": "https://rsample.tidymodels.org/logo.png",
+    "last_updated": "2026-01-30",
+    "authors": [
+      {
+        "name": "Hannah Frick",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-6049-5258",
+        "directory_id": "hannah-frick",
+        "email": "hannah@posit.co"
+      },
+      {
+        "name": "Fanny Chow",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Max Kuhn",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Michael Mahoney",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-2402-304X"
+      },
+      {
+        "name": "Julia Silge",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-3671-836X",
+        "directory_id": "julia-silge"
+      },
+      {
+        "name": "Hadley Wickham",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Posit Software"
+      },
+      {
+        "name": "PBC",
+        "roles": [
+          "cph",
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "RSSthemes",
+    "title": "RSS Palettes and Themes",
+    "description": "Defines colour palettes and themes for Royal Statistical Society (RSS) publications, including Significance magazine. Palettes and themes are supported in both base R and 'ggplot2' graphics, and are intended to be used by authors submitting to RSS publications.",
+    "repo_url": "https://github.com/nrennie/RSSthemes",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/nrennie/RSSthemes/issues",
+    "logo_url": {},
+    "last_updated": "2024-03-02",
+    "authors": [
+      {
+        "name": "Nicola Rennie",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "directory_id": "nicola-rennie",
+        "email": "nrennie35@gmail.com"
+      },
+      {
+        "name": "Royal Statistical Society",
+        "roles": [
+          "fnd",
+          "cph"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "rstanemax",
+    "title": "Emax Model Analysis with 'Stan'",
+    "description": "Perform sigmoidal Emax model fit using 'Stan' in a formula notation, without writing 'Stan' model code.",
+    "repo_url": "https://github.com/yoshidk6/rstanemax",
+    "pkdown_url": "https://yoshidk6.github.io/rstanemax/",
+    "bug_reports_url": "https://github.com/yoshidk6/rstanemax/issues",
+    "logo_url": {},
+    "last_updated": "2025-02-17",
+    "authors": [
+      {
+        "name": "Kenta Yoshida",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0003-4967-3831",
+        "email": "yoshida.kenta.6@gmail.com"
+      },
+      {
+        "name": "Danielle Navarro",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0001-7648-6578",
+        "directory_id": "danielle-navarro"
+      },
+      {
+        "name": "Trustees of Columbia University",
+        "roles": [
+          "cph"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "sessioncheck",
+    "title": "Checks Session Status",
+    "description": "Provides tools to check variables contained in the user environment, and inspect the currently loaded package namespaces. The intended use is to allow user scripts to throw errors or warnings if unwanted variables exist or if unwanted packages are loaded.",
+    "repo_url": "https://github.com/djnavarro/sessioncheck",
+    "pkdown_url": "https://sessioncheck.djnavarro.net/",
+    "bug_reports_url": "https://github.com/djnavarro/sessioncheck/issues",
+    "logo_url": {},
+    "last_updated": "2026-02-27",
+    "authors": [
+      {
+        "name": "Danielle Navarro",
+        "roles": [
+          "aut",
+          "cre",
+          "cph"
+        ],
+        "directory_id": "danielle-navarro",
+        "email": "djnavarro@protonmail.com"
+      }
+    ]
+  },
+  {
+    "name": "sfnetworks",
+    "title": "Tidy Geospatial Networks",
+    "description": "Provides a tidy approach to spatial network analysis, in the form of classes and functions that enable a seamless interaction between the network analysis package 'tidygraph' and the spatial analysis package 'sf'.",
+    "repo_url": "https://github.com/luukvdmeer/sfnetworks",
+    "pkdown_url": "https://luukvdmeer.github.io/sfnetworks/",
+    "bug_reports_url": "https://github.com/luukvdmeer/sfnetworks/issues/",
+    "logo_url": "https://luukvdmeer.github.io/sfnetworks/logo.png",
+    "last_updated": "2024-12-06",
+    "authors": [
+      {
+        "name": "Lucas van der Meer",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-6336-8628",
+        "email": "luukvandermeer@live.nl"
+      },
+      {
+        "name": "Lorena Abad",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-0554-734X",
+        "directory_id": "lorena-abad"
+      },
+      {
+        "name": "Andrea Gilardi",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-9424-7439"
+      },
+      {
+        "name": "Robin Lovelace",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0001-5679-6536"
+      }
+    ]
+  },
+  {
+    "name": "shinyMobile",
+    "title": "Mobile Ready 'shiny' Apps with Standalone Capabilities",
+    "description": "Develop outstanding 'shiny' apps for 'iOS' and 'Android' as well as beautiful 'shiny' gadgets. 'shinyMobile' is built on top of the latest 'Framework7' template <https://framework7.io>. Discover 14 new input widgets (sliders, vertical sliders, stepper, grouped action buttons, toggles, picker, smart select, ...), 2 themes (light and dark), 12 new widgets (expandable cards, badges, chips, timelines, gauges, progress bars, ...) combined with the power of server-side notifications such as alerts, modals, toasts, action sheets, sheets (and more) as well as 3 layouts (single, tabs and split).",
+    "repo_url": "https://github.com/RinteRface/shinyMobile",
+    "pkdown_url": "https://rinterface.github.io/shinyMobile/",
+    "bug_reports_url": "https://github.com/RinteRface/shinyMobile/issues",
+    "logo_url": "https://rinterface.github.io/shinyMobile/logo.png",
+    "last_updated": "2024-10-04",
+    "authors": [
+      {
+        "name": "David Granjon",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "email": "dgranjon@ymail.com"
+      },
+      {
+        "name": "Veerle van Leemput",
+        "roles": [
+          "aut"
+        ],
+        "directory_id": "veerle-van-leemput"
+      },
+      {
+        "name": "AthlyticZ",
+        "roles": [
+          "fnd"
+        ]
+      },
+      {
+        "name": "Victor Perrier",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "John Coene",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Isabelle Rudolf",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Dieter Menne",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Marvelapp",
+        "roles": [
+          "ctb",
+          "cph"
+        ]
+      },
+      {
+        "name": "Vladimir Kharlampidi",
+        "roles": [
+          "ctb",
+          "cph"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "shinymodels",
+    "title": "Interactive Assessments of Models",
+    "description": "Launch a 'shiny' application for 'tidymodels' results. For classification or regression models, the app can be used to determine if there is lack of fit or poorly predicted points.",
+    "repo_url": "https://github.com/tidymodels/shinymodels",
+    "pkdown_url": "https://shinymodels.tidymodels.org",
+    "bug_reports_url": "https://github.com/tidymodels/shinymodels/issues",
+    "logo_url": {},
+    "last_updated": "2024-01-31",
+    "authors": [
+      {
+        "name": "Max Kuhn",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-2402-136X"
+      },
+      {
+        "name": "Shisham Adhikari",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Julia Silge",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-3671-836X",
+        "directory_id": "julia-silge"
+      },
+      {
+        "name": "Simon Couch",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-5676-5107",
+        "email": "simon.couch@posit.co"
+      },
+      {
+        "name": "Posit Software"
+      },
+      {
+        "name": "PBC",
+        "roles": [
+          "cph",
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "siga",
+    "title": "Descargar y Leer Datos del SIGA",
+    "description": "Descarga y lee datos del Sistema de Información y Gestión Agrometeorológica del INTA <http://siga.inta.gob.ar/>.",
+    "repo_url": "https://github.com/AgRoMeteorologiaINTA/siga",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/AgRoMeteorologiaINTA/siga/issues",
+    "logo_url": {},
+    "last_updated": "2024-05-21",
+    "authors": [
+      {
+        "name": "Yanina Bellini Saibene",
+        "roles": [
+          "cre",
+          "ctb"
+        ],
+        "directory_id": "yanina-bellini-saibene",
+        "email": "yabellini@gmail.com"
+      },
+      {
+        "name": "Elio Campitelli",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-7742-9230"
+      },
+      {
+        "name": "Paola Corrales",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Natalia Gattinoni",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "INTA",
+        "roles": [
+          "cph"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "SISINTAR",
+    "title": "Lee y Manipula Datos de Suelo de SISINTA",
+    "description": "Permite descargar y manipular datos de perfiles de suelo disponibles en la plataforma SISINTA.",
+    "repo_url": "https://github.com/inta-suelos/SISINTAR",
+    "pkdown_url": {},
+    "bug_reports_url": {},
+    "logo_url": {},
+    "last_updated": "2023-05-30",
+    "authors": [
+      {
+        "name": "Yanina Bellini Saibene",
+        "roles": [
+          "cre",
+          "ctb"
+        ],
+        "directory_id": "yanina-bellini-saibene",
+        "email": "yabellini@gmail.com"
+      },
+      {
+        "name": "Elio Campitelli",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-7742-9230"
+      },
+      {
+        "name": "Paola Corrales",
+        "roles": [
+          "aut"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "spatialsample",
+    "title": "Spatial Resampling Infrastructure",
+    "description": "Functions and classes for spatial resampling to use with the 'rsample' package, such as spatial cross-validation (Brenning, 2012) <doi:10.1109/IGARSS.2012.6352393>. The scope of 'rsample' and 'spatialsample' is to provide the basic building blocks for creating and analyzing resamples of a spatial data set, but neither package includes functions for modeling or computing statistics. The resampled spatial data sets created by 'spatialsample' do not contain much overhead in memory.",
+    "repo_url": "https://github.com/tidymodels/spatialsample",
+    "pkdown_url": "https://spatialsample.tidymodels.org",
+    "bug_reports_url": "https://github.com/tidymodels/spatialsample/issues",
+    "logo_url": "https://spatialsample.tidymodels.org/logo.png",
+    "last_updated": "2025-12-02",
+    "authors": [
+      {
+        "name": "Michael Mahoney",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0003-2402-304X",
+        "email": "mike.mahoney.218@gmail.com"
+      },
+      {
+        "name": "Julia Silge",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-3671-836X",
+        "directory_id": "julia-silge"
+      },
+      {
+        "name": "Posit Software"
+      },
+      {
+        "name": "PBC",
+        "roles": [
+          "cph",
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "statsr",
+    "title": "Companion Software for the Coursera Statistics with R\nSpecialization",
+    "description": "Data and functions to support Bayesian and frequentist inference and decision making for the Coursera Specialization \"Statistics with R\". See <https://github.com/StatsWithR/statsr> for more information.",
+    "repo_url": "https://github.com/StatsWithR/statsr",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/StatsWithR/statsr/issues",
+    "logo_url": {},
+    "last_updated": "2021-01-22",
+    "authors": [
+      {
+        "name": "Colin Rundel",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Mine Cetinkaya-Rundel",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Merlise Clyde",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "email": "clyde@duke.edu"
+      },
+      {
+        "name": "David Banks",
+        "roles": [
+          "aut"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "TextMiningTutorial",
+    "title": "What the Package Does (One Line, Title Case)",
+    "description": "Tutorial de introducción a Text Mining",
+    "repo_url": "https://github.com/yabellini/TextMiningTutorial",
+    "pkdown_url": {},
+    "bug_reports_url": {},
+    "logo_url": {},
+    "last_updated": "2021-05-19",
+    "authors": [
+      {
+        "name": "Yanina Bellini Saibene",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "directory_id": "yanina-bellini-saibene",
+        "email": "yabellini@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "tidylo",
+    "title": "Weighted Tidy Log Odds Ratio",
+    "description": "How can we measure how the usage or frequency of some feature, such as words, differs across some group or set, such as documents? One option is to use the log odds ratio, but the log odds ratio alone does not account for sampling variability; we haven't counted every feature the same number of times so how do we know which differences are meaningful? Enter the weighted log odds, which 'tidylo' provides an implementation for, using tidy data principles. In particular, here we use the method outlined in Monroe, Colaresi, and Quinn (2008) <doi:10.1093/pan/mpn018> to weight the log odds ratio by a prior. By default, the prior is estimated from the data itself, an empirical Bayes approach, but an uninformative prior is also available.",
+    "repo_url": "https://github.com/juliasilge/tidylo",
+    "pkdown_url": "https://juliasilge.github.io/tidylo/",
+    "bug_reports_url": "https://github.com/juliasilge/tidylo/issues",
+    "logo_url": {},
+    "last_updated": "2022-03-22",
+    "authors": [
+      {
+        "name": "Tyler Schnoebelen",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Julia Silge",
+        "roles": [
+          "aut",
+          "cre",
+          "cph"
+        ],
+        "orcid": "0000-0002-3671-836X",
+        "directory_id": "julia-silge",
+        "email": "julia.silge@gmail.com"
+      },
+      {
+        "name": "Alex Hayes",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-4985-5160"
+      }
+    ]
+  },
+  {
+    "name": "tidyquintro",
+    "title": "Quick Intro to Tidyverse",
+    "description": "A 4 hour workshop with quick introduction to tidyverse.",
+    "repo_url": "https://github.com/drmowinckels/tidyquintro",
+    "pkdown_url": {},
+    "bug_reports_url": {},
+    "logo_url": {},
+    "last_updated": "2022-10-10",
+    "authors": [
+      {
+        "name": "Athanasia Mo Mowinckel",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-5756-0223",
+        "directory_id": "athanasia-mo-mowinckel",
+        "email": "a.m.mowinckel@psykologi.uio.no"
+      }
+    ]
+  },
+  {
+    "name": "tidytext",
+    "title": "Text Mining using 'dplyr', 'ggplot2', and Other Tidy Tools",
+    "description": "Using tidy data principles can make many text mining tasks easier, more effective, and consistent with tools already in wide use. Much of the infrastructure needed for text mining with tidy data frames already exists in packages like 'dplyr', 'broom', 'tidyr', and 'ggplot2'. In this package, we provide functions and supporting data sets to allow conversion of text to and from tidy formats, and to switch seamlessly between tidy tools and existing text mining packages.",
+    "repo_url": "https://github.com/juliasilge/tidytext",
+    "pkdown_url": "https://juliasilge.github.io/tidytext/",
+    "bug_reports_url": "https://github.com/juliasilge/tidytext/issues",
+    "logo_url": "https://juliasilge.github.io/tidytext/logo.png",
+    "last_updated": "2026-02-21",
+    "authors": [
+      {
+        "name": "Gabriela De Queiroz",
+        "roles": [
+          "ctb"
+        ],
+        "directory_id": "gabriela-de-queiroz"
+      },
+      {
+        "name": "Colin Fay",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0001-7343-1846"
+      },
+      {
+        "name": "Emil Hvitfeldt",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Os Keyes",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0001-5196-609X"
+      },
+      {
+        "name": "Kanishka Misra",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Tim Mastny",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Jeff Erickson",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "David Robinson",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Julia Silge",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-3671-836X",
+        "directory_id": "julia-silge",
+        "email": "julia.silge@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "tinkr",
+    "title": "Cast '(R)Markdown' Files to 'XML' and Back Again",
+    "description": "Parsing '(R)Markdown' files with numerous regular expressions can be fraught with peril, but it does not have to be this way. Converting '(R)Markdown' files to 'XML' using the 'commonmark' package allows in-memory editing via of 'markdown' elements via 'XPath' through the extensible 'R6' class called 'yarn'. These modified 'XML' representations can be written to '(R)Markdown' documents via an 'xslt' stylesheet which implements an extended version of 'GitHub'-flavoured 'markdown' so that you can tinker to your hearts content.",
+    "repo_url": "https://github.com/ropensci/tinkr",
+    "pkdown_url": "https://docs.ropensci.org/tinkr/",
+    "bug_reports_url": "https://github.com/ropensci/tinkr/issues",
+    "logo_url": "https://docs.ropensci.org/tinkr/logo.png",
+    "last_updated": "2025-10-04",
+    "authors": [
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon"
+      },
+      {
+        "name": "Zhian N. Kamvar",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0003-1458-7108",
+        "email": "zkamvar@gmail.com"
+      },
+      {
+        "name": "Jeroen Ooms",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Nick Wellnhofer",
+        "roles": [
+          "cph"
+        ]
+      },
+      {
+        "name": "rOpenSci",
+        "roles": [
+          "fnd"
+        ]
+      },
+      {
+        "name": "Peter Daengeli",
+        "roles": [
+          "ctb"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "traudem",
+    "title": "Use TauDEM",
+    "description": "Simple trustworthy utility functions to use TauDEM (Terrain Analysis Using Digital Elevation Models <https://hydrology.usu.edu/taudem/taudem5/>) command-line interface. This package provides a guide to installation of TauDEM and its dependencies GDAL (Geopatial Data Abstraction Library) and MPI (Message Passing Interface) for different operating systems. Moreover, it checks that TauDEM and its dependencies are correctly installed and included to the PATH, and it provides wrapper commands for calling TauDEM methods from R.",
+    "repo_url": "https://github.com/lucarraro/traudem",
+    "pkdown_url": "https://lucarraro.github.io/traudem/",
+    "bug_reports_url": "https://github.com/lucarraro/traudem/issues",
+    "logo_url": {},
+    "last_updated": "2024-04-24",
+    "authors": [
+      {
+        "name": "Luca Carraro",
+        "roles": [
+          "cre",
+          "aut"
+        ],
+        "email": "Luca.Carraro@eawag.ch"
+      },
+      {
+        "name": "University of Zurich",
+        "roles": [
+          "cph",
+          "fnd"
+        ]
+      },
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon"
+      },
+      {
+        "name": "Wael Sadek",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Kirill Müller",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-1416-3412"
+      }
+    ]
+  },
+  {
+    "name": "TutorialgRaficosFN",
+    "title": "Tutorial sobre Gráficos en R",
+    "description": "Tutorial para generar gráficos en R festejando a Florence Nightingale",
+    "repo_url": "https://github.com/yabellini/TutorialgRaficosFN",
+    "pkdown_url": {},
+    "bug_reports_url": {},
+    "logo_url": {},
+    "last_updated": "2021-05-11",
+    "authors": [
+      {
+        "name": "Yanina Bellini Saibene",
+        "directory_id": "yanina-bellini-saibene",
+        "email": "yabellini@gmail.com"
+      },
+      {
+        "name": "Yanina Bellini Saibene",
+        "roles": [
+          "cre"
+        ],
+        "directory_id": "yanina-bellini-saibene",
+        "email": "yabellini@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "TutorialIterar",
+    "title": "Tutoriales de learnr para aprender sobre iteracción en R",
+    "description": "este paquete contiene dos turoriales de learnr para aprender for loops y map.",
+    "repo_url": "https://github.com/yabellini/TutorialIterar",
+    "pkdown_url": {},
+    "bug_reports_url": {},
+    "logo_url": {},
+    "last_updated": "2021-04-25",
+    "authors": [
+      {
+        "name": "Yanina Bellini Saibene",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "directory_id": "yanina-bellini-saibene",
+        "email": "yabellini@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "typeR",
+    "title": "Simulate Typing Script",
+    "description": "Simulates typing of R script files for presentations and demonstrations. Provides character-by-character animation with optional live code execution. Supports R scripts (.R), R Markdown (.Rmd), and Quarto (.qmd) documents.",
+    "repo_url": "https://github.com/Fgazzelloni/typeR",
+    "pkdown_url": "https://Fgazzelloni.github.io/typeR/",
+    "bug_reports_url": "https://github.com/Fgazzelloni/typeR/issues",
+    "logo_url": "https://Fgazzelloni.github.io/typeR/logo.png",
+    "last_updated": "2026-02-08",
+    "authors": [
+      {
+        "name": "Federica Gazzelloni",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "directory_id": "federica-gazzelloni",
+        "email": "fede.gazzelloni@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "uiothemes",
+    "title": "Branding themes for the University of Oslo, Norway",
+    "description": "Contains templates, themeing files and functions. Made specifically for branding purposes for the University of Oslo.",
+    "repo_url": "https://github.com/drmowinckels/uiothemes",
+    "pkdown_url": {},
+    "bug_reports_url": {},
+    "logo_url": {},
+    "last_updated": "2020-10-29",
+    "authors": [
+      {
+        "name": "Athanasia Mo Mowinckel",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-5756-0223",
+        "directory_id": "athanasia-mo-mowinckel",
+        "email": "a.m.mowinckel@psykologi.uio.no"
+      }
+    ]
+  },
+  {
+    "name": "ukbabynames",
+    "title": "UK Baby Names Data",
+    "description": "Full listing of UK baby names occurring more than three times per year between 1974 and 2020, and rankings of baby name popularity by decade from 1904 to 1994.",
+    "repo_url": "https://github.com/mine-cetinkaya-rundel/ukbabynames",
+    "pkdown_url": "https://mine-cetinkaya-rundel.github.io/ukbabynames/",
+    "bug_reports_url": "https://github.com/mine-cetinkaya-rundel/ukbabynames/issues",
+    "logo_url": {},
+    "last_updated": "2022-03-25",
+    "authors": [
+      {
+        "name": "Mine Çetinkaya-Rundel",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-6452-2420",
+        "email": "cetinkaya.mine@gmail.com"
+      },
+      {
+        "name": "Thomas J. Leeper",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Nicholas Goguen-Compagnoni",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Sara Lemus",
+        "roles": [
+          "aut"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "usdata",
+    "title": "Data on the States and Counties of the United States",
+    "description": "Demographic data on the United States at the county and state levels spanning multiple years.",
+    "repo_url": "https://github.com/OpenIntroStat/usdata",
+    "pkdown_url": "https://openintrostat.github.io/usdata/",
+    "bug_reports_url": "https://github.com/OpenIntroStat/usdata/issues",
+    "logo_url": "https://openintrostat.github.io/usdata/logo.png",
+    "last_updated": "2024-06-02",
+    "authors": [
+      {
+        "name": "Mine Çetinkaya-Rundel",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0001-6452-2420",
+        "email": "cetinkaya.mine@gmail.com"
+      },
+      {
+        "name": "David Diez",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Leah Dorazio",
+        "roles": [
+          "aut"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "vcr",
+    "title": "Record 'HTTP' Calls to Disk",
+    "description": "Record test suite 'HTTP' requests and replays them during future runs. A port of the Ruby gem of the same name (<https://github.com/vcr/vcr/>). Works by recording real 'HTTP' requests/responses on disk in 'cassettes', and then replaying matching responses on subsequent requests.",
+    "repo_url": "https://github.com/ropensci/vcr/",
+    "pkdown_url": "https://books.ropensci.org/http-testing/",
+    "bug_reports_url": "https://github.com/ropensci/vcr/issues",
+    "logo_url": {},
+    "last_updated": "2025-12-05",
+    "authors": [
+      {
+        "name": "Scott Chamberlain",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0003-1444-9135",
+        "email": "myrmecocystus@gmail.com"
+      },
+      {
+        "name": "Aaron Wolen",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0003-2542-2202"
+      },
+      {
+        "name": "Maëlle Salmon",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-2815-0399",
+        "directory_id": "maelle-salmon"
+      },
+      {
+        "name": "Daniel Possenriede",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-6738-9845"
+      },
+      {
+        "name": "Hadley Wickham",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "rOpenSci",
+        "roles": [
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "verbaliseR",
+    "title": "Make your Text Mighty Fine",
+    "description": "Turn R analysis outputs into full sentences, by writing vectors into in-sentence lists, pluralising words conditionally, spelling out numbers if they are at the start of sentences, writing out dates in full following US or UK style, and managing capitalisations in tidy data.",
+    "repo_url": "https://github.com/cararthompson/verbaliseR",
+    "pkdown_url": {},
+    "bug_reports_url": "https://github.com/cararthompson/verbaliseR/issues",
+    "logo_url": {},
+    "last_updated": "2022-10-04",
+    "authors": [
+      {
+        "name": "Cara Thompson",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-6472-5073",
+        "email": "cara.r.thompson@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "vetiver",
+    "title": "Version, Share, Deploy, and Monitor Models",
+    "description": "The goal of 'vetiver' is to provide fluent tooling to version, share, deploy, and monitor a trained model. Functions handle both recording and checking the model's input data prototype, and predicting from a remote API endpoint. The 'vetiver' package is extensible, with generics that can support many kinds of models.",
+    "repo_url": "https://github.com/rstudio/vetiver-r/",
+    "pkdown_url": "https://vetiver.posit.co",
+    "bug_reports_url": "https://github.com/rstudio/vetiver-r/issues",
+    "logo_url": {},
+    "last_updated": "2025-12-13",
+    "authors": [
+      {
+        "name": "Julia Silge",
+        "roles": [
+          "cre",
+          "aut"
+        ],
+        "orcid": "0000-0002-3671-836X",
+        "directory_id": "julia-silge",
+        "email": "julia.silge@posit.co"
+      },
+      {
+        "name": "Posit Software"
+      },
+      {
+        "name": "PBC",
+        "roles": [
+          "cph",
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "washi",
+    "title": "Washington Soil Health Initiative Branding",
+    "description": "Create plots and tables in a consistent style with WaSHI (Washington Soil Health Initiative) branding. Use 'washi' to easily style your 'ggplot2' plots and 'flextable' tables.",
+    "repo_url": "https://github.com/WA-Department-of-Agriculture/washi",
+    "pkdown_url": "https://wa-department-of-agriculture.github.io/washi/",
+    "bug_reports_url": "https://github.com/WA-Department-of-Agriculture/washi/issues/",
+    "logo_url": "https://wa-department-of-agriculture.github.io/washi/logo.png",
+    "last_updated": "2025-09-16",
+    "authors": [
+      {
+        "name": "Jadey Ryan",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "email": "jryan@agr.wa.gov"
+      },
+      {
+        "name": "Molly McIlquham",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Dani Gelardi",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Washington State Department of Agriculture",
+        "roles": [
+          "cph",
+          "fnd"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "weathercan",
+    "title": "Download Weather Data from Environment and Climate Change Canada",
+    "description": "Provides means for downloading historical weather data from the Environment and Climate Change Canada website (<https://climate.weather.gc.ca/historical_data/search_historic_data_e.html>). Data can be downloaded from multiple stations and over large date ranges and automatically processed into a single dataset. Tools are also provided to identify stations either by name or proximity to a location.",
+    "repo_url": "https://github.com/ropensci/weathercan/",
+    "pkdown_url": "https://docs.ropensci.org/weathercan/",
+    "bug_reports_url": "https://github.com/ropensci/weathercan/issues/",
+    "logo_url": "https://docs.ropensci.org/weathercan/logo.png",
+    "last_updated": "2026-01-19",
+    "authors": [
+      {
+        "name": "Steffi LaZerte",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-7690-8360",
+        "directory_id": "steffi-lazerte",
+        "email": "sel@steffilazerte.ca"
+      },
+      {
+        "name": "Sam Albers",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-9270-7884"
+      },
+      {
+        "name": "Nick Brown",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-2719-0671"
+      },
+      {
+        "name": "Kevin Cazelles",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0001-6619-9874"
+      },
+      {
+        "name": "Richard Littauer",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0001-5428-7535"
+      },
+      {
+        "name": "Shandiya Balasubramaniam",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0001-9928-9964"
+      },
+      {
+        "name": "Mark Ciechanowski",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-3732-5939"
+      },
+      {
+        "name": "Jeremy Selva",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-4498-2662"
+      },
+      {
+        "name": "Kelli F. Johnson",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-5149-451X"
+      },
+      {
+        "name": "Russ Allen",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Everett Snieder",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0003-4997-3404"
+      },
+      {
+        "name": "Josh Persi",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0000-0002-2700-6483"
+      },
+      {
+        "name": "Mahjabin Oyshi",
+        "roles": [
+          "ctb"
+        ],
+        "orcid": "0009-0000-7992-6727"
+      }
+    ]
+  },
+  {
+    "name": "widyr",
+    "title": "Widen, Process, then Re-Tidy Data",
+    "description": "Encapsulates the pattern of untidying data into a wide matrix, performing some processing, then turning it back into a tidy form. This is useful for several operations such as co-occurrence counts, correlations, or clustering that are mathematically convenient on wide matrices.",
+    "repo_url": "https://github.com/juliasilge/widyr",
+    "pkdown_url": "https://juliasilge.github.io/widyr/",
+    "bug_reports_url": "https://github.com/juliasilge/widyr/issues",
+    "logo_url": {},
+    "last_updated": "2026-03-09",
+    "authors": [
+      {
+        "name": "David Robinson",
+        "roles": [
+          "aut"
+        ]
+      },
+      {
+        "name": "Kanishka Misra",
+        "roles": [
+          "ctb"
+        ]
+      },
+      {
+        "name": "Julia Silge",
+        "roles": [
+          "aut",
+          "cre"
+        ],
+        "orcid": "0000-0002-3671-836X",
+        "directory_id": "julia-silge",
+        "email": "julia.silge@gmail.com"
+      }
+    ]
+  },
+  {
+    "name": "worrrd",
+    "title": "Generate Wordsearch and Crossword Puzzles",
+    "description": "Generate wordsearch and crossword puzzles using custom lists of words (and clues). Make them easy or hard, and print them to solve offline with paper and pencil!",
+    "repo_url": "https://github.com/anthonypileggi/worrrd",
+    "pkdown_url": "https://www.stochastic-squirrel.com/worrrd/",
+    "bug_reports_url": "https://github.com/anthonypileggi/worrrd/issues",
+    "logo_url": "https://www.stochastic-squirrel.com/worrrd/logo.png",
+    "last_updated": "2022-10-25",
+    "authors": [
+      {
+        "name": "Anthony Pileggi",
+        "roles": [
+          "aut",
+          "cre",
+          "cph"
+        ],
+        "email": "apileggi20@gmail.com"
+      },
+      {
+        "name": "Shannon Pileggi",
+        "roles": [
+          "aut"
+        ],
+        "orcid": "0000-0002-7732-4164",
+        "directory_id": "shannon-pileggi"
       }
     ]
   }

--- a/scripts/discover_packages.R
+++ b/scripts/discover_packages.R
@@ -1,0 +1,422 @@
+library(jsonlite)
+library(here)
+
+content_dir <- here::here("data/content")
+packages_dir <- here::here("data/packages")
+directory_dir <- here::here("..", "directory", "data", "json")
+
+`%||%` <- function(a, b) if (is.null(a) || length(a) == 0) b else a
+
+ascii <- function(x) {
+  if (length(x) == 0) return(character(0))
+  iconv(x, to = "ASCII//TRANSLIT", sub = "")
+}
+
+is_blank <- function(x) {
+  is.null(x) || length(x) == 0 || all(is.na(x)) || !nzchar(trimws(paste(x, collapse = "")))
+}
+
+read_authors <- function(dir) {
+  files <- list.files(dir, pattern = "\\.json$", full.names = TRUE)
+  out <- list()
+  for (f in files) {
+    blog <- jsonlite::read_json(f)
+    for (a in blog$authors %||% list()) {
+      sm <- a$social_media[[1]] %||% list()
+      out[[length(out) + 1]] <- list(
+        name = a$name,
+        github = sm$github %||% NA_character_,
+        orcid = sm$orcid %||% NA_character_,
+        blog = blog$url
+      )
+    }
+  }
+  out
+}
+
+# Build a name/handle -> directory slug lookup from the sibling rladies/directory
+# repo. The slug (filename minus .json) is the canonical directory_id.
+build_directory_lookup <- function(dir) {
+  if (!dir.exists(dir)) {
+    message("Directory repo not found at ", normalizePath(dir, mustWork = FALSE),
+            " — directory_id lookup will be skipped.")
+    return(list(by_handle = list(), by_name = list()))
+  }
+  files <- list.files(dir, pattern = "\\.json$", full.names = TRUE)
+  by_handle <- list()
+  by_name <- list()
+  for (f in files) {
+    entry <- tryCatch(jsonlite::read_json(f), error = function(e) NULL)
+    if (is.null(entry)) next
+    id <- sub("\\.json$", "", basename(f))
+    gh <- entry$social_media$github
+    if (!is_blank(gh)) by_handle[[tolower(trimws(gh))]] <- id
+    if (!is_blank(entry$name)) {
+      by_name[[tolower(trimws(ascii(entry$name)))]] <- id
+    }
+  }
+  message("Loaded ", length(files), " directory entries from ", dir)
+  list(by_handle = by_handle, by_name = by_name)
+}
+
+lookup_directory_id <- function(name, github, dir_lookup) {
+  if (!is_blank(github)) {
+    h <- tolower(trimws(github))
+    if (!is.null(dir_lookup$by_handle[[h]])) return(dir_lookup$by_handle[[h]])
+  }
+  if (!is_blank(name)) {
+    n <- tolower(trimws(ascii(name)))
+    if (!is.null(dir_lookup$by_name[[n]])) return(dir_lookup$by_name[[n]])
+  }
+  NA_character_
+}
+
+to_iso_date <- function(s) {
+  if (is_blank(s)) return(NA_character_)
+  m <- regmatches(s, regexpr("\\d{4}-\\d{2}-\\d{2}", s))
+  if (length(m) == 0) NA_character_ else m
+}
+
+universe_url <- function(handle) {
+  sprintf(
+    "https://%s.r-universe.dev/api/packages?fields=Package,Title,Description,URL,BugReports,Maintainer,Author,_owner,Date/Publication,_published",
+    tolower(handle)
+  )
+}
+
+fetch_universe <- function(handle) {
+  url <- universe_url(handle)
+  con <- curl::curl(url)
+  on.exit(close(con), add = TRUE)
+  resp <- tryCatch(readLines(con, warn = FALSE), error = function(e) NULL)
+  if (is.null(resp)) return(NULL)
+  txt <- paste(resp, collapse = "\n")
+  if (!nzchar(txt) || startsWith(txt, "{")) return(NULL)
+  tryCatch(jsonlite::fromJSON(txt, simplifyVector = FALSE),
+           error = function(e) NULL)
+}
+
+fetch_universe_package <- function(owner, pkg) {
+  url <- sprintf(
+    "https://%s.r-universe.dev/api/packages/%s?fields=Package,Title,Description,URL,BugReports,Maintainer,Author,_owner,Date/Publication,_published",
+    tolower(owner), pkg
+  )
+  con <- curl::curl(url)
+  on.exit(close(con), add = TRUE)
+  resp <- tryCatch(readLines(con, warn = FALSE), error = function(e) NULL)
+  if (is.null(resp)) return(NULL)
+  tryCatch(jsonlite::fromJSON(paste(resp, collapse = "\n"), simplifyVector = FALSE),
+           error = function(e) NULL)
+}
+
+# HEAD probe pkgdown standard logo paths. Returns the first 200 URL or NA.
+probe_logo_url <- function(pkdown_url) {
+  if (is_blank(pkdown_url)) return(NA_character_)
+  base <- sub("/+$", "", pkdown_url)
+  candidates <- c(
+    paste0(base, "/logo.png"),
+    paste0(base, "/logo.svg"),
+    paste0(base, "/reference/figures/logo.png"),
+    paste0(base, "/reference/figures/logo.svg")
+  )
+  for (u in candidates) {
+    h <- curl::new_handle()
+    curl::handle_setopt(h, customrequest = "HEAD", nobody = TRUE,
+                        followlocation = TRUE, timeout = 5)
+    resp <- tryCatch(curl::curl_fetch_memory(u, handle = h),
+                     error = function(e) NULL)
+    if (!is.null(resp) && resp$status_code == 200) return(u)
+  }
+  NA_character_
+}
+
+owner_match <- function(pkg, handle) {
+  isTRUE(tolower(pkg$`_owner` %||% "") == tolower(handle))
+}
+
+name_in <- function(needle, haystack) {
+  if (is_blank(needle) || is_blank(haystack)) return(FALSE)
+  grepl(tolower(ascii(needle)), tolower(ascii(haystack)), fixed = TRUE)
+}
+
+accepted_roles <- c("cre", "aut")
+
+roles_for <- function(name, author_text) {
+  if (is_blank(author_text)) return("unknown")
+  hay <- tolower(ascii(author_text))
+  needle <- tolower(ascii(name))
+  pos <- regexpr(needle, hay, fixed = TRUE)
+  if (pos == -1) return(character(0))
+  tail <- substr(hay, pos + attr(pos, "match.length"), nchar(hay))
+  m <- regmatches(tail, regexpr("\\s*\\[([^]]+)\\]", tail))
+  if (length(m) == 0) return("unknown")
+  inside <- sub("^\\s*\\[", "", sub("\\]$", "", m))
+  trimws(strsplit(inside, ",")[[1]])
+}
+
+is_authorship <- function(name, author_text, maintainer_text) {
+  if (name_in(name, maintainer_text)) return(TRUE)
+  r <- roles_for(name, author_text)
+  if (identical(r, "unknown")) return(TRUE)
+  any(r %in% accepted_roles)
+}
+
+split_author_entries <- function(text) {
+  s <- gsub("\\s+", " ", text)
+  chars <- strsplit(s, "", fixed = TRUE)[[1]]
+  if (length(chars) == 0) return(character(0))
+  depth_b <- 0L
+  depth_p <- 0L
+  cuts <- integer(0)
+  for (i in seq_along(chars)) {
+    ch <- chars[i]
+    if (ch == "[") depth_b <- depth_b + 1L
+    else if (ch == "]") depth_b <- max(depth_b - 1L, 0L)
+    else if (ch == "(") depth_p <- depth_p + 1L
+    else if (ch == ")") depth_p <- max(depth_p - 1L, 0L)
+    else if (ch == "," && depth_b == 0L && depth_p == 0L) cuts <- c(cuts, i)
+  }
+  starts <- c(1L, cuts + 1L)
+  ends <- c(cuts - 1L, length(chars))
+  parts <- vapply(seq_along(starts), function(k) {
+    paste(chars[starts[k]:ends[k]], collapse = "")
+  }, character(1))
+  trimws(parts[nzchar(trimws(parts))])
+}
+
+parse_authors <- function(text) {
+  if (is_blank(text)) return(list())
+  parts <- split_author_entries(text)
+  lapply(parts, function(p) {
+    roles_m <- regmatches(p, regexpr("\\[([^]]*)\\]", p))
+    roles <- if (length(roles_m) > 0) {
+      trimws(strsplit(gsub("^\\[|\\]$", "", roles_m), ",")[[1]])
+    } else {
+      character(0)
+    }
+    orcid_m <- regmatches(p, regexpr("\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]", p, perl = TRUE))
+    orcid <- if (length(orcid_m) > 0) orcid_m else NA_character_
+    boundary <- regexpr("[\\[\\(]", p, perl = TRUE)
+    name <- if (boundary > 0) trimws(substr(p, 1, boundary - 1)) else trimws(p)
+    list(name = name, roles = as.list(roles), orcid = orcid)
+  })
+}
+
+parse_pkg_urls <- function(url_str) {
+  if (is_blank(url_str)) {
+    return(list(repo_url = NA_character_, pkdown_url = NA_character_, other = list()))
+  }
+  parts <- trimws(unlist(strsplit(url_str, "[,\n]")))
+  parts <- parts[nzchar(parts)]
+  is_gh <- grepl("github\\.com|gitlab\\.com|codeberg\\.org", parts)
+  list(
+    repo_url = if (any(is_gh)) parts[which(is_gh)[1]] else NA_character_,
+    pkdown_url = if (any(!is_gh)) parts[which(!is_gh)[1]] else NA_character_,
+    other = as.list(c(parts[is_gh][-1], parts[!is_gh][-1]))
+  )
+}
+
+parse_maintainer_str <- function(m) {
+  if (is_blank(m)) return(list(name = NA_character_, email = NA_character_))
+  email_m <- regmatches(m, regexpr("<([^>]+)>", m))
+  email <- if (length(email_m) > 0) gsub("[<>]", "", email_m) else NA_character_
+  name <- trimws(sub("\\s*<[^>]*>\\s*$", "", m))
+  list(name = name, email = email)
+}
+
+# Build a single person entry (name, roles, orcid, directory_id). Used for
+# both `authors` and `maintainers` arrays. Maintainer-specific fields like
+# `email` are added by the caller.
+person_entry <- function(person, dir_lookup) {
+  out <- list(name = person$name)
+  if (length(person$roles) > 0) out$roles <- person$roles
+  if (!is_blank(person$orcid)) out$orcid <- person$orcid
+  did <- lookup_directory_id(person$name, NA, dir_lookup)
+  if (!is.na(did)) out$directory_id <- did
+  out
+}
+
+to_package_shape <- function(cand, dir_lookup) {
+  urls <- parse_pkg_urls(cand$url)
+  m <- parse_maintainer_str(cand$maintainer)
+
+  repo_url <- urls$repo_url
+  if (is.na(repo_url) && !is_blank(cand$repo_owner) && !is_blank(cand$package)) {
+    repo_url <- sprintf("https://github.com/%s/%s", cand$repo_owner, cand$package)
+  }
+  if (is.na(repo_url) && !is_blank(cand$bug_reports)) {
+    repo_url <- sub("/issues/?$", "", cand$bug_reports)
+  }
+
+  parsed <- cand$authors
+  # Some old DESCRIPTION fields are role-less; if we know who the maintainer is
+  # from the Maintainer field but they're missing from Author, inject them.
+  has_cre <- any(vapply(parsed, function(a) "cre" %in% unlist(a$roles), logical(1)))
+  if (!has_cre && !is.na(m$name)) {
+    parsed <- c(parsed, list(list(name = m$name, roles = list("cre"),
+                                  orcid = NA_character_)))
+  }
+
+  authors <- lapply(parsed, function(a) {
+    entry <- person_entry(a, dir_lookup)
+    if (!is.na(m$email) && name_in(a$name, m$name)) {
+      entry$email <- m$email
+    }
+    entry
+  })
+
+  logo_url <- probe_logo_url(urls$pkdown_url)
+
+  list(
+    name = cand$package,
+    title = str_or_na(cand$title),
+    description = str_or_na(cand$description),
+    repo_url = str_or_na(repo_url),
+    pkdown_url = str_or_na(urls$pkdown_url),
+    bug_reports_url = str_or_na(cand$bug_reports),
+    logo_url = str_or_na(logo_url),
+    last_updated = str_or_na(cand$last_updated),
+    authors = authors
+  )
+}
+
+merge_pkg <- function(existing, new) {
+  if (length(existing) == 0) return(new)
+  scalar_fields <- c("name", "title", "description", "repo_url", "pkdown_url",
+                     "bug_reports_url", "logo_url", "last_updated")
+  for (f in scalar_fields) {
+    if (is_blank(existing[[f]]) && !is_blank(new[[f]])) {
+      existing[[f]] <- new[[f]]
+    }
+  }
+  if (is_blank(existing$authors) && length(new$authors) > 0) {
+    existing$authors <- new$authors
+  }
+  existing
+}
+
+write_pkg <- function(entry, dir) {
+  path <- file.path(dir, paste0(entry$name, ".json"))
+  existing <- if (file.exists(path)) jsonlite::read_json(path) else list()
+  merged <- merge_pkg(existing, entry)
+  if (!dir.exists(dir)) dir.create(dir, recursive = TRUE)
+  jsonlite::write_json(merged, path, pretty = TRUE, auto_unbox = TRUE, na = "null")
+}
+
+str_or_na <- function(x) {
+  if (is_blank(x)) NA_character_ else as.character(x)
+}
+
+normalise_pkg <- function(pkg, source, matched_author, handle = NA, roles = NULL) {
+  desc <- str_or_na(pkg$Description)
+  if (!is.na(desc)) desc <- trimws(gsub("\\s+", " ", desc))
+  last_updated <- to_iso_date(pkg$`Date/Publication`) %||% to_iso_date(pkg$`_published`)
+  list(
+    package = str_or_na(pkg$Package),
+    title = str_or_na(pkg$Title),
+    description = desc,
+    repo_owner = str_or_na(pkg$`_owner`),
+    url = str_or_na(pkg$URL),
+    bug_reports = str_or_na(pkg$BugReports),
+    maintainer = str_or_na(pkg$Maintainer),
+    last_updated = last_updated,
+    authors = parse_authors(pkg$Author),
+    matched_author = matched_author,
+    matched_handle = handle,
+    matched_roles = roles %||% NA_character_,
+    source = source
+  )
+}
+
+# ---- Pipeline ---------------------------------------------------------------
+
+cat("Loading author list from", content_dir, "\n")
+authors <- read_authors(content_dir)
+cat("  found", length(authors), "author entries\n")
+
+cat("Building R-Ladies directory lookup from", directory_dir, "\n")
+dir_lookup <- build_directory_lookup(directory_dir)
+cat("  ", length(dir_lookup$by_handle), "github handles, ",
+    length(dir_lookup$by_name), "names indexed\n")
+
+candidates <- list()
+
+cat("Querying R-universe per author...\n")
+for (a in authors) {
+  if (is.na(a$github)) next
+  pkgs <- fetch_universe(a$github)
+  if (is.null(pkgs) || length(pkgs) == 0) next
+  for (p in pkgs) {
+    is_owner <- owner_match(p, a$github)
+    name_hit <- name_in(a$name, p$Maintainer) || name_in(a$name, p$Author)
+    if (!is_owner && !name_hit) next
+    if (!is_owner && !is_authorship(a$name, p$Author, p$Maintainer)) next
+    roles <- roles_for(a$name, p$Author)
+    if (length(roles) == 0) roles <- "owner"
+    candidates[[length(candidates) + 1]] <-
+      normalise_pkg(p, "r-universe", a$name, a$github, paste(roles, collapse = ","))
+  }
+  cat("  ", a$github, "->", length(pkgs), "in universe\n")
+}
+
+cat("Fetching CRAN package db...\n")
+cran <- tryCatch(tools::CRAN_package_db(), error = function(e) NULL)
+if (!is.null(cran)) {
+  cat("  ", nrow(cran), "CRAN packages\n")
+  for (a in authors) {
+    hits <- which(
+      vapply(cran$Author,    function(s) name_in(a$name, s), logical(1)) |
+      vapply(cran$Maintainer,function(s) name_in(a$name, s), logical(1))
+    )
+    for (i in hits) {
+      row <- cran[i, ]
+      if (!is_authorship(a$name, row$Author, row$Maintainer)) next
+      roles <- paste(roles_for(a$name, row$Author), collapse = ",")
+      candidates[[length(candidates) + 1]] <- list(
+        package = row$Package,
+        title = row$Title,
+        description = trimws(gsub("\\s+", " ", row$Description %||% "")),
+        repo_owner = NA_character_,
+        url = row$URL,
+        bug_reports = row$BugReports,
+        maintainer = row$Maintainer,
+        last_updated = to_iso_date(row[["Date/Publication"]]),
+        authors = parse_authors(row$Author),
+        matched_author = a$name,
+        matched_handle = a$github,
+        matched_roles = roles,
+        source = "cran"
+      )
+    }
+  }
+}
+
+cat("Total raw candidate rows:", length(candidates), "\n")
+dedup_key <- vapply(candidates, function(x) tolower(x$package %||% ""), character(1))
+candidates <- candidates[!duplicated(dedup_key) & nzchar(dedup_key)]
+cat("After dedupe by package name:", length(candidates), "\n")
+
+# Drop entries where the package failed to build in r-universe (no title and
+# no description means we have nothing usable).
+candidates <- Filter(function(x) !(is_blank(x$title) && is_blank(x$description)),
+                     candidates)
+cat("After dropping unbuilt packages:", length(candidates), "\n")
+
+cat("Writing per-package files to", packages_dir, "\n")
+for (cand in candidates) {
+  entry <- to_package_shape(cand, dir_lookup)
+  write_pkg(entry, packages_dir)
+}
+
+cat("Enriching meetupr from rladies r-universe...\n")
+mp <- fetch_universe_package("rladies", "meetupr")
+if (!is.null(mp) && !is.null(mp$Package)) {
+  cand_mp <- normalise_pkg(mp, "r-universe", "R-Ladies Global", "rladies", "cph")
+  entry_mp <- to_package_shape(cand_mp, dir_lookup)
+  write_pkg(entry_mp, packages_dir)
+  cat("  meetupr updated\n")
+} else {
+  cat("  could not fetch meetupr metadata\n")
+}
+
+cat("Done.", length(candidates), "candidate package files written (+meetupr).\n")

--- a/scripts/json_schema/packages.json
+++ b/scripts/json_schema/packages.json
@@ -5,19 +5,29 @@
         "name": {
             "type": "string"
         },
+        "title": {
+            "type": "string"
+        },
         "description": {
             "type": "string"
         },
         "repo_url": {
-            "type": "string"
+            "type": ["string", "null"]
         },
         "pkdown_url": {
-            "type": "string"
+            "type": ["string", "null"]
+        },
+        "bug_reports_url": {
+            "type": ["string", "null"]
         },
         "logo_url": {
-            "type": "string"
+            "type": ["string", "null"]
         },
-        "maintainers": {
+        "last_updated": {
+            "type": ["string", "null"],
+            "description": "ISO date (YYYY-MM-DD) of last publication: r-universe Date/Publication, falling back to _published or CRAN Date/Publication."
+        },
+        "authors": {
             "type": "array",
             "items": {
                 "type": "object",
@@ -26,59 +36,28 @@
                         "type": "string"
                     },
                     "email": {
-                        "type": "string"
+                        "type": ["string", "null"]
                     },
-                    "social_media": {
-                        "type": "object",
-                        "properties": {
-                            "twitter": {
-                                "type": "string"
-                            },
-                            "mastodon": {
-                                "type": "string"
-                            },
-                            "bluesky": {
-                                "type": "string"
-                            },
-                            "linkedin": {
-                                "type": "string"
-                            },
-                            "facebook": {
-                                "type": "string"
-                            },
-                            "github": {
-                                "type": "string"
-                            },
-                            "instagram": {
-                                "type": "string"
-                            },
-                            "youtube": {
-                                "type": "string"
-                            },
-                            "tiktok": {
-                                "type": "string"
-                            },
-                            "website": {
-                                "type": "string"
-                            },
-                            "orcid": {
-                                "type": "string"
-                            }
-                        },
-                        "additionalProperties": true
+                    "directory_id": {
+                        "type": ["string", "null"]
+                    },
+                    "orcid": {
+                        "type": ["string", "null"]
+                    },
+                    "roles": {
+                        "type": "array",
+                        "items": { "type": "string" }
                     }
                 },
-                "required": [
-                    "name"
-                ],
+                "required": ["name"],
                 "additionalProperties": true
             }
         }
     },
     "required": [
         "name",
-        "maintainers",
-        "description"
+        "description",
+        "authors"
     ],
     "additionalProperties": true
 }


### PR DESCRIPTION
## Summary

- Add `scripts/discover_packages.R` and run it to harvest ~100 R package JSONs maintained by R-Ladies blog authors into `data/packages/`.
- Refresh `data/packages/meetupr.json` and `scripts/json_schema/packages.json` to use `authors` (with `roles`) instead of the old `maintainers` field.
- Fix the README rendering for the new repo structure: switch packages chunk from missing `x\$maintainers` to `x\$authors`, coalesce null `repo_url` to `pkdown_url`/`bug_reports_url` (e.g. BayesERtools has no GitHub URL), and emit bullets via a single `cat()` with a leading newline so the list doesn't collapse into a wrapped paragraph.
- Fix `knit_readme.yaml`: the aggregation step was passing bash-style `Rscript -e '...'` to a step whose `shell` was `Rscript {0}`, so it failed. Now `source()`s the script directly. Also restricts the push trigger to relevant paths and `git add`s before committing so new files in `data/website/` are picked up.

## Test plan

- [ ] CI: `Knit readme and aggregate website JSONs` runs on merge to main and produces a clean commit updating `README.md` and `data/website/awesome_*.json`.
- [ ] Locally rendered `README.md` shows proper bullet lists for both blogs and packages, no collapsed paragraphs.
- [ ] `data/website/awesome_packages.json` and `data/website/awesome_content.json` are valid JSON arrays consumable by the R-Ladies website.
- [ ] Validate workflow still passes for the new package JSONs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)