### PR TITLE
Add issue-form-based package submission flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-package.yaml
+++ b/.github/ISSUE_TEMPLATE/new-package.yaml
@@ -1,0 +1,66 @@
+name: New Package
+description: Submit an R package to the awesome-rladies-creations list
+title: "[New Package]: "
+labels: ["package-submission"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for adding an R package! :package:
+        Most metadata is fetched automatically from r-universe or CRAN.
+        The package must be discoverable on r-universe, CRAN, or both.
+  - type: input
+    id: package_name
+    attributes:
+      label: Package name
+      description: Exact name of the package as published (case-sensitive).
+      placeholder: ex. ggplot2
+    validations:
+      required: true
+  - type: input
+    id: r_universe_handle
+    attributes:
+      label: r-universe owner handle
+      description: |
+        GitHub user or org whose r-universe instance hosts this package
+        (i.e. the `<handle>` in `https://<handle>.r-universe.dev`).
+        Leave blank if the package is only on CRAN.
+      placeholder: ex. tidyverse
+    validations:
+      required: false
+  - type: input
+    id: author_directory_id
+    attributes:
+      label: Author directory ID (optional)
+      description: |
+        If a primary author has an entry in the
+        [R-Ladies directory](https://github.com/rladies/directory),
+        the slug for their JSON file (filename without `.json`).
+        We'll use this to link the package to their directory profile.
+      placeholder: ex. firstname-lastname
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional notes (optional)
+      description: Anything else we should know? Co-authors, special considerations, etc.
+    validations:
+      required: false
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: This package is maintained by, or has substantial contribution from, an R-Ladies community member.
+          required: true
+        - label: I am the package author/maintainer, OR I will get explicit consent from them before this submission is merged.
+          required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](http://rladies.org/code-of-conduct/).
+      options:
+        - label: I agree to follow R-Ladies' Code of Conduct.
+          required: true

--- a/.github/workflows/process_package_submission.yaml
+++ b/.github/workflows/process_package_submission.yaml
@@ -1,0 +1,102 @@
+name: Process new package submission
+
+on:
+  issues:
+    types: [opened, edited, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  build:
+    if: contains(github.event.issue.labels.*.name, 'package-submission')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Parse issue
+        id: parse
+        uses: stefanbuck/github-issue-parser@v3
+        with:
+          template-path: .github/ISSUE_TEMPLATE/new-package.yaml
+
+      - name: Install cURL Headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install libcurl4-openssl-dev
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'renv'
+
+      - name: Setup renv
+        uses: r-lib/actions/setup-renv@v2
+
+      - name: Build package JSON
+        id: build
+        env:
+          PKG_NAME: ${{ steps.parse.outputs.issueparser_package_name }}
+          PKG_HANDLE: ${{ steps.parse.outputs.issueparser_r_universe_handle }}
+          PKG_DIR_ID: ${{ steps.parse.outputs.issueparser_author_directory_id }}
+        run: |
+          Rscript scripts/add_package.R "$PKG_NAME" "$PKG_HANDLE" "$PKG_DIR_ID"
+          echo "json_path=data/packages/${PKG_NAME}.json" >> "$GITHUB_OUTPUT"
+
+      - name: Open pull request
+        if: success()
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: package-submission/issue-${{ github.event.issue.number }}
+          base: main
+          title: "Add ${{ steps.parse.outputs.issueparser_package_name }} (closes #${{ github.event.issue.number }})"
+          commit-message: |
+            Add ${{ steps.parse.outputs.issueparser_package_name }} from issue #${{ github.event.issue.number }}
+
+            Co-authored-by: ${{ github.event.issue.user.login }} <${{ github.event.issue.user.login }}@users.noreply.github.com>
+          body: |
+            Automated submission generated from issue #${{ github.event.issue.number }}.
+
+            Submitted by @${{ github.event.issue.user.login }}.
+
+            - **Package:** `${{ steps.parse.outputs.issueparser_package_name }}`
+            - **r-universe handle:** `${{ steps.parse.outputs.issueparser_r_universe_handle }}`
+            - **Author directory id:** `${{ steps.parse.outputs.issueparser_author_directory_id }}`
+
+            Closes #${{ github.event.issue.number }}.
+          add-paths: data/packages/*.json
+
+      - name: Comment success on issue
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'Built a draft PR for `${{ steps.parse.outputs.issueparser_package_name }}`. A maintainer will review it shortly.'
+            });
+
+      - name: Comment failure on issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                "Could not build the package metadata automatically. Please check the [workflow logs](" +
+                  context.serverUrl + "/" + context.repo.owner + "/" + context.repo.repo +
+                  "/actions/runs/" + context.runId + ").",
+                "",
+                "Common causes: package name is misspelled, package isn't on r-universe under the given handle, or it isn't on CRAN.",
+                "A maintainer will follow up."
+              ].join('\n')
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,9 @@ Each entry is a single JSON file which is used to render pages and to generate a
 
 If you are not comfortable editing JSON directly, open an issue using the repository issue template and provide the details and we can help create the file for you.
 
-There are two main ways to add an entry:
+There are three ways to add an entry:
 
+- **Easiest (packages only):** open an issue with the [New Package](../../issues/new?template=new-package.yaml) form. Provide the package name and r-universe handle (or leave the handle blank for a CRAN-only package). A workflow fetches metadata from r-universe/CRAN, generates the JSON, and opens a draft PR linked to your issue. A maintainer reviews and merges.
 - Use the GitHub UI to create a new file in the appropriate folder (links below).
 - Fork or branch locally, add the JSON file, and create a pull request.
 

--- a/scripts/add_package.R
+++ b/scripts/add_package.R
@@ -1,0 +1,95 @@
+library(jsonlite)
+library(here)
+
+# Sources fetch_universe_package, normalise_pkg, parse_authors, to_package_shape,
+# write_pkg, build_directory_lookup, to_iso_date, %||%, etc. Pipeline at the
+# bottom of discover_packages.R is gated by sys.nframe() and skipped when
+# sourced.
+source(here::here("scripts/discover_packages.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 1 || !nzchar(args[1])) {
+  stop(
+    "Usage: Rscript scripts/add_package.R <pkg> [r-universe-handle] [author-directory-id]"
+  )
+}
+pkg_name <- args[1]
+handle <- if (length(args) >= 2 && nzchar(args[2])) args[2] else NA_character_
+dir_id <- if (length(args) >= 3 && nzchar(args[3])) args[3] else NA_character_
+
+cat("Building entry for", pkg_name,
+    if (!is.na(handle)) sprintf("(handle: %s)", handle) else "(no handle)",
+    "\n")
+
+cand <- NULL
+
+if (!is.na(handle)) {
+  pkg_meta <- fetch_universe_package(handle, pkg_name)
+  if (!is.null(pkg_meta) && !is.null(pkg_meta$Package)) {
+    cat("Fetched from r-universe (", handle, ")\n", sep = "")
+    cand <- normalise_pkg(
+      pkg_meta,
+      source = "r-universe",
+      matched_author = NA_character_,
+      handle = handle
+    )
+  } else {
+    cat("Not found on r-universe, falling back to CRAN\n")
+  }
+}
+
+if (is.null(cand)) {
+  cran <- tryCatch(tools::CRAN_package_db(), error = function(e) NULL)
+  if (is.null(cran)) {
+    stop("CRAN package db unreachable and no r-universe match for ", pkg_name)
+  }
+  row <- cran[cran$Package == pkg_name, , drop = FALSE]
+  if (nrow(row) == 0) {
+    stop("Package '", pkg_name, "' not found on r-universe or CRAN")
+  }
+  cat("Fetched from CRAN\n")
+  cand <- list(
+    package = row$Package,
+    title = row$Title,
+    description = trimws(gsub("\\s+", " ", row$Description %||% "")),
+    repo_owner = NA_character_,
+    url = row$URL,
+    bug_reports = row$BugReports,
+    maintainer = row$Maintainer,
+    last_updated = to_iso_date(row[["Date/Publication"]]),
+    authors = parse_authors(row$Author),
+    matched_author = NA_character_,
+    matched_handle = NA_character_,
+    matched_roles = NA_character_,
+    source = "cran"
+  )
+}
+
+directory_dir <- here::here("..", "directory", "data", "json")
+dir_lookup <- if (dir.exists(directory_dir)) {
+  build_directory_lookup(directory_dir)
+} else {
+  list(by_handle = list(), by_name = list())
+}
+
+entry <- to_package_shape(cand, dir_lookup)
+
+if (!is.na(dir_id) && length(entry$authors) > 0) {
+  entry$authors[[1]]$directory_id <- dir_id
+}
+
+packages_dir <- here::here("data/packages")
+write_pkg(entry, packages_dir)
+
+out_path <- file.path(packages_dir, paste0(entry$name, ".json"))
+cat("Wrote", out_path, "\n")
+
+schema_path <- here::here("scripts/json_schema/packages.json")
+if (file.exists(schema_path) && requireNamespace("jsonvalidate", quietly = TRUE)) {
+  validator <- jsonvalidate::json_validator(schema_path)
+  ok <- validator(out_path, verbose = TRUE, error = FALSE, greedy = TRUE)
+  if (!isTRUE(ok)) {
+    stop("Schema validation failed for ", out_path)
+  }
+  cat("Schema validation passed\n")
+}

--- a/scripts/discover_packages.R
+++ b/scripts/discover_packages.R
@@ -329,6 +329,8 @@ normalise_pkg <- function(pkg, source, matched_author, handle = NA, roles = NULL
 }
 
 # ---- Pipeline ---------------------------------------------------------------
+# Skipped when this file is sourced from another script (sys.nframe() > 0).
+run_pipeline <- function() {
 
 cat("Loading author list from", content_dir, "\n")
 authors <- read_authors(content_dir)
@@ -420,3 +422,7 @@ if (!is.null(mp) && !is.null(mp$Package)) {
 }
 
 cat("Done.", length(candidates), "candidate package files written (+meetupr).\n")
+
+}
+
+if (sys.nframe() == 0) run_pipeline()


### PR DESCRIPTION
## Summary

Adds a low-friction way for community members to submit a new R package without editing JSON by hand.

- **Issue form** (\`.github/ISSUE_TEMPLATE/new-package.yaml\`) with three inputs: package name (required), r-universe handle (optional, CRAN-only packages can omit it), author directory_id (optional, links to the rladies/directory entry). Submitters tick consent and CoC boxes.
- **Workflow** (\`.github/workflows/process_package_submission.yaml\`) gates on the \`package-submission\` label, parses the form with [\`stefanbuck/github-issue-parser\`](https://github.com/stefanbuck/github-issue-parser), runs the builder, and opens a draft PR via [\`peter-evans/create-pull-request\`](https://github.com/peter-evans/create-pull-request). It comments on the issue on success or failure.
- **Single-package builder** (\`scripts/add_package.R\`) reuses the existing helpers from \`discover_packages.R\`. Tries r-universe first via the supplied handle, falls back to CRAN if r-universe doesn't have the package, applies an optional \`directory_id\` to the first author, and validates against \`scripts/json_schema/packages.json\`.
- **Helper gating** in \`scripts/discover_packages.R\`: wrap the bulk pipeline so sourcing the file no longer triggers a full harvest. \`Rscript scripts/discover_packages.R\` still runs the full thing.
- \`CONTRIBUTING.md\`: point contributors at the new form as the easiest path. (Wider doc cleanup — stale \`maintainers\` references etc. — left for a follow-up.)

## How it flows

1. Contributor opens the *New Package* issue form. The label \`package-submission\` is auto-applied.
2. Workflow parses the form, runs \`Rscript scripts/add_package.R <pkg> [handle] [dir_id]\`.
3. The script fetches r-universe metadata (or CRAN) and writes \`data/packages/<pkg>.json\`.
4. \`peter-evans/create-pull-request\` opens a PR closing the issue, with the submitter as a co-author.

## Operational note

\`peter-evans/create-pull-request\` needs **Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests** enabled. If it isn't, the action will fail at the PR-create step. The \`author-consent\` and \`package-submission\` labels are already created on the repo.

## Test plan

- [x] Builder works locally for r-universe package (\`Rscript scripts/add_package.R targets ropensci\`)
- [x] Builder falls back to CRAN when no handle is given (\`Rscript scripts/add_package.R yaml\`)
- [x] Builder errors cleanly when both r-universe and CRAN don't know the package
- [x] Schema validation runs against the generated file
- [x] Sourcing \`discover_packages.R\` no longer triggers the bulk pipeline
- [ ] After merge: open a real test issue and confirm the workflow opens a PR end-to-end
- [ ] After merge: verify the bot's PR has correct co-author attribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)