### PR TITLE
Fix JSON metadata validation script and workflow

### DIFF
--- a/.github/workflows/validate_jsons.yaml
+++ b/.github/workflows/validate_jsons.yaml
@@ -1,12 +1,25 @@
+name: Validate JSON metadata
+
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
+    branches: [main]
     paths:
-    - 'blogs/**'
+      - 'data/content/**'
+      - 'data/packages/**'
+      - 'scripts/json_schema/**'
+      - 'scripts/validate_jsons.R'
+      - '.github/workflows/validate_jsons.yaml'
+  push:
+    branches: [main]
+    paths:
+      - 'data/content/**'
+      - 'data/packages/**'
+      - 'scripts/json_schema/**'
 
-name: Validate and clean jsons
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate:
@@ -14,20 +27,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v12
-        with:
-          files: blogs/
-
-      - name: Cleanup json template comments
-        if: ${{ steps.changed-files.outputs.any_changed }}
-        run: |
-          for f in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            echo Cleaning $f 
-            sed -i 's.//required..g' $f
-          done
 
       - name: Install cURL Headers
         run: |
@@ -37,19 +36,10 @@ jobs:
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
-          version: 'renv'
+          r-version: "renv"
 
       - name: Setup renv
         uses: r-lib/actions/setup-renv@v2
 
-      - name: Validate jsons
-        run: Rscript 'scripts/validate_jsons.R'
-        
-      - name: Commit data
-        env:
-          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git commit blogs/ -m 'Commit cleaned jsons' || echo "No changes to commit"
-          git push origin || echo "Nothing to push"  
+      - name: Validate JSON metadata
+        run: Rscript scripts/validate_jsons.R

--- a/scripts/validate_jsons.R
+++ b/scripts/validate_jsons.R
@@ -1,34 +1,50 @@
-validate_jsons <- function(files, schema) {
-  validate <- jsonvalidate::json_validator(
-    schema
-  )
-  k <- sapply(files, validate, verbose = TRUE, error = TRUE, greedy = TRUE)
+library(jsonlite)
+library(jsonvalidate)
+library(here)
+
+validate_dir <- function(dir, schema) {
+  files <- list.files(dir, pattern = "\\.json$", full.names = TRUE)
+  if (length(files) == 0) {
+    cat("No JSON files in", dir, "- skipping\n")
+    return(invisible(TRUE))
+  }
+  validator <- jsonvalidate::json_validator(schema, engine = "ajv")
+  cat("Validating", length(files), "files in", dir, "against", basename(schema), "\n")
+  failures <- character(0)
+  for (f in files) {
+    ok <- validator(f, verbose = TRUE, error = FALSE, greedy = TRUE)
+    if (!isTRUE(ok)) {
+      failures <- c(failures, f)
+      cat("  FAIL:", basename(f), "\n")
+      errors <- attr(ok, "errors")
+      if (!is.null(errors)) print(errors)
+    }
+  }
+  if (length(failures) > 0) {
+    return(invisible(failures))
+  }
+  cat("  All", length(files), "files valid.\n")
+  invisible(TRUE)
 }
 
-files <- list.files(
-  path = here::here("content"),
-  full.names = TRUE
+content_failures <- validate_dir(
+  here::here("data/content"),
+  here::here("scripts/json_schema/content.json")
 )
-ext <- grep("json$", files, invert = TRUE)
-if (length(ext) > 0) {
+package_failures <- validate_dir(
+  here::here("data/packages"),
+  here::here("scripts/json_schema/packages.json")
+)
+
+all_failures <- c(
+  if (!isTRUE(content_failures)) content_failures,
+  if (!isTRUE(package_failures)) package_failures
+)
+if (length(all_failures) > 0) {
   stop(
-    "File has wrong extention. Please rename to end with 'json'\n",
-    paste0(
-      basename(files[grep("json$", files, invert = TRUE)]),
-      collapse = "\n"
-    ),
+    "Validation failed for ", length(all_failures), " file(s):\n  ",
+    paste(all_failures, collapse = "\n  "),
     call. = FALSE
   )
 }
-
-#  Validate content json
-validate_jsons(
-  files,
-  here::here("scripts/json_schema/content.json")
-)
-
-#  Validate packages json
-validate_jsons(
-  files,
-  here::here("scripts/json_schema/packages.json")
-)
+cat("All JSON files valid.\n")


### PR DESCRIPTION
## Summary

The existing \`validate_jsons.R\` script listed files from a stale \`content/\` path and validated the same list against *both* schemas, so it never actually validated anything correctly. The companion workflow triggered on \`blogs/**\` (which no longer exists). Rewrite both so they actually check the JSON we ship.

- **\`scripts/validate_jsons.R\`**: validates \`data/content/*.json\` against \`content.json\`, \`data/packages/*.json\` against \`packages.json\`. Collects failures across both directories and exits non-zero with a list of bad files. Verified locally — all 45 content + 103 package files pass.
- **\`.github/workflows/validate_jsons.yaml\`**: triggers on PRs and pushes that touch \`data/content/**\`, \`data/packages/**\`, the schemas, or the validator itself. Drops the broken auto-commit step (couldn't run from forks anyway) and the obsolete template-comment cleanup (the new issue-form submission path doesn't produce \`//required\` artefacts).

## Test plan

- [x] Local run on the current dataset reports "All JSON files valid."
- [ ] CI: workflow fires on a PR that adds or modifies a package JSON, and fails when the JSON is invalid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)