### PR TITLE
Add ggseg ecosystem and nettskjemar packages

### DIFF
--- a/data/packages/bakeoff.json
+++ b/data/packages/bakeoff.json
@@ -16,7 +16,8 @@
         "cph"
       ],
       "orcid": "0000-0002-8082-1890",
-      "email": "apreshill@gmail.com"
+      "email": "apreshill@gmail.com",
+      "directory_id": "alison-presmanes-hill"
     },
     {
       "name": "Chester Ismay",

--- a/data/packages/dados.json
+++ b/data/packages/dados.json
@@ -46,7 +46,8 @@
       "roles": [
         "aut"
       ],
-      "orcid": "0000-0003-0762-7618"
+      "orcid": "0000-0003-0762-7618",
+      "directory_id": "alejandra-tapia"
     },
     {
       "name": "Beatriz Maurer Costa",

--- a/data/packages/ggseg.extra.json
+++ b/data/packages/ggseg.extra.json
@@ -1,0 +1,38 @@
+{
+  "name": "ggseg.extra",
+  "title": "Create Brain Atlases for the 'ggsegverse' Plotting Ecosystem",
+  "description": "Create brain atlas data sets compatible with the 'ggsegverse' plotting packages in 'R'. Provides pipelines for building cortical, subcortical, and white-matter tract atlases from 'FreeSurfer' annotation files, 'GIFTI' and 'CIFTI' surface formats, 'neuromaps', and volumetric 'NIfTI' images.",
+  "repo_url": "https://github.com/ggsegverse/ggseg.extra",
+  "pkdown_url": null,
+  "bug_reports_url": "https://github.com/ggsegverse/ggseg.extra/issues",
+  "logo_url": "https://raw.githubusercontent.com/ggsegverse/ggseg.extra/HEAD/man/figures/logo.png",
+  "last_updated": "2026-03-29",
+  "authors": [
+    {
+      "name": "Athanasia Mo Mowinckel",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "orcid": "0000-0002-5756-0223",
+      "directory_id": "athanasia-mo-mowinckel",
+      "email": "a.m.mowinckel@psykologi.uio.no"
+    },
+    {
+      "name": "Didac Vidal-Piñeiro",
+      "roles": [
+        "ctb",
+        "cph"
+      ],
+      "orcid": "0000-0001-9997-9156"
+    },
+    {
+      "name": "John Muschelli",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0001-6469-1750"
+    }
+  ]
+}

--- a/data/packages/ggseg.formats.json
+++ b/data/packages/ggseg.formats.json
@@ -1,0 +1,31 @@
+{
+  "name": "ggseg.formats",
+  "title": "Brain Atlas Data Structures for the 'ggseg' Ecosystem",
+  "description": "Provides the 'ggseg_atlas' S3 class used across the 'ggseg' ecosystem for 2D and 3D brain visualisation. Ships three bundled atlases ('Desikan-Killiany', 'FreeSurfer' 'aseg', 'TRACULA') and functions for querying, subsetting, renaming, and enriching atlas objects. Also includes readers for 'FreeSurfer' statistics files.",
+  "repo_url": "https://github.com/ggsegverse/ggseg.formats",
+  "pkdown_url": "https://ggsegverse.github.io/ggseg.formats/",
+  "bug_reports_url": "https://github.com/ggsegverse/ggseg.formats/issues",
+  "logo_url": null,
+  "last_updated": "2026-04-03",
+  "authors": [
+    {
+      "name": "Athanasia Mo Mowinckel",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-5756-0223",
+      "directory_id": "athanasia-mo-mowinckel",
+      "email": "a.m.mowinckel@psykologi.uio.no"
+    },
+    {
+      "name": "Center for Lifespan Changes in Brain and Cognition"
+    },
+    {
+      "name": "University of Oslo",
+      "roles": [
+        "cph"
+      ]
+    }
+  ]
+}

--- a/data/packages/ggseg.json
+++ b/data/packages/ggseg.json
@@ -1,0 +1,50 @@
+{
+  "name": "ggseg",
+  "title": "Plotting Tool for Brain Atlases",
+  "description": "Provides a 'ggplot2' geom and position for visualizing brain region data on cortical, subcortical, and white matter tract atlases. Brain atlas geometries are stored as simple features ('sf'), enabling seamless integration with the 'ggplot2' ecosystem including faceting, custom scales, and themes. Mowinckel & Vidal-Piñeiro (2020) <doi:10.1177/2515245920928009>.",
+  "repo_url": "https://github.com/ggsegverse/ggseg",
+  "pkdown_url": "https://ggsegverse.github.io/ggseg/",
+  "bug_reports_url": "https://github.com/ggsegverse/ggseg/issues",
+  "logo_url": "https://ggsegverse.github.io/ggseg/logo.png",
+  "last_updated": "2026-04-16",
+  "authors": [
+    {
+      "name": "Athanasia Mo Mowinckel",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "orcid": "0000-0002-5756-0223",
+      "directory_id": "athanasia-mo-mowinckel",
+      "email": "a.m.mowinckel@psykologi.uio.no"
+    },
+    {
+      "name": "Didac Vidal-Piñeiro",
+      "roles": [
+        "aut",
+        "cph"
+      ],
+      "orcid": "0000-0001-9997-9156"
+    },
+    {
+      "name": "Ramiro Magno",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-5226-3441"
+    },
+    {
+      "name": "Center for Lifespan Changes in Brain and Cognition"
+    },
+    {
+      "name": "University of Oslo"
+    },
+    {
+      "name": "Norway",
+      "roles": [
+        "cph"
+      ]
+    }
+  ]
+}

--- a/data/packages/ggseg.meshes.json
+++ b/data/packages/ggseg.meshes.json
@@ -1,0 +1,31 @@
+{
+  "name": "ggseg.meshes",
+  "title": "Additional Brain Surface Meshes for the 'ggsegverse' Ecosystem",
+  "description": "Provides additional brain surface meshes for cortical and cerebellar visualisation in the 'ggsegverse' ecosystem. Cortical surfaces include pial, white, midthickness, semi-inflated, sphere, smoothwm, and orig at fsaverage5 resolution. Cerebellar surfaces include the Spatially Unbiased Infratentorial Template (SUIT) flatmap. All meshes follow the same vertices/faces data frame format used by 'ggseg.formats' and 'ggseg3d'.",
+  "repo_url": "https://github.com/ggsegverse/ggseg.meshes",
+  "pkdown_url": "https://ggsegverse.github.io/ggseg.meshes/",
+  "bug_reports_url": "https://github.com/ggsegverse/ggseg.meshes/issues",
+  "logo_url": "https://ggsegverse.github.io/ggseg.meshes/logo.png",
+  "last_updated": "2026-04-09",
+  "authors": [
+    {
+      "name": "Athanasia Mo Mowinckel",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-5756-0223",
+      "directory_id": "athanasia-mo-mowinckel",
+      "email": "a.m.mowinckel@psykologi.uio.no"
+    },
+    {
+      "name": "Center for Lifespan Changes in Brain and Cognition"
+    },
+    {
+      "name": "University of Oslo",
+      "roles": [
+        "cph"
+      ]
+    }
+  ]
+}

--- a/data/packages/ggseg3d.json
+++ b/data/packages/ggseg3d.json
@@ -1,0 +1,45 @@
+{
+  "name": "ggseg3d",
+  "title": "Interactive 3D Brain Atlas Visualization",
+  "description": "Plot brain atlases as interactive 3D meshes using 'Three.js' via 'htmlwidgets', or render publication-quality static images through 'rgl' and 'rayshader'. A pipe-friendly API lets you map data onto brain regions, control camera angles, toggle region edges, overlay glass brains, and snapshot or ray-trace the result. Additional atlases are available through the 'ggsegverse' r-universe. Mowinckel & Vidal-Piñeiro (2020) <doi:10.1177/2515245920928009>.",
+  "repo_url": "https://github.com/ggsegverse/ggseg3d",
+  "pkdown_url": "https://ggsegverse.github.io/ggseg3d/",
+  "bug_reports_url": "https://github.com/ggsegverse/ggseg3d/issues",
+  "logo_url": "https://ggsegverse.github.io/ggseg3d/logo.png",
+  "last_updated": "2026-04-22",
+  "authors": [
+    {
+      "name": "Athanasia Mo Mowinckel",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-5756-0223",
+      "directory_id": "athanasia-mo-mowinckel",
+      "email": "a.m.mowinckel@psykologi.uio.no"
+    },
+    {
+      "name": "Didac Vidal-Piñeiro",
+      "roles": [
+        "aut"
+      ],
+      "orcid": "0000-0001-9997-9156"
+    },
+    {
+      "name": "Center for Lifespan Changes in Brain and Cognition"
+    },
+    {
+      "name": "University of Oslo",
+      "roles": [
+        "cph"
+      ]
+    },
+    {
+      "name": "three.js authors",
+      "roles": [
+        "ctb",
+        "cph"
+      ]
+    }
+  ]
+}

--- a/data/packages/namer.json
+++ b/data/packages/namer.json
@@ -42,7 +42,8 @@
       "roles": [
         "ctb"
       ],
-      "orcid": "0000-0002-3039-6849"
+      "orcid": "0000-0002-3039-6849",
+      "directory_id": "charlie-joey-hadley"
     },
     {
       "name": "Jumping Rivers",

--- a/data/packages/nettskjemar.json
+++ b/data/packages/nettskjemar.json
@@ -1,0 +1,29 @@
+{
+  "name": "nettskjemar",
+  "title": "Connect to the 'nettskjema.no' API of the University of Oslo",
+  "description": "Enables users to retrieve data, meta-data, and codebooks from <https://nettskjema.no/>. The data from the API is richer than from the online data portal. This package is not developed by the University of Oslo IT. Mowinckel (2021) <doi:10.5281/zenodo.4745481>.",
+  "repo_url": "https://github.com/CAPRO-UiO/nettskjemar",
+  "pkdown_url": "https://zenodo.org/badge/latestdoi/206264675",
+  "bug_reports_url": "https://github.com/capro-uio/nettskjemar/issues",
+  "logo_url": "https://raw.githubusercontent.com/CAPRO-UiO/nettskjemar/HEAD/man/figures/logo.png",
+  "last_updated": "2025-09-08",
+  "authors": [
+    {
+      "name": "Athanasia Mo Mowinckel",
+      "roles": [
+        "aut",
+        "cre"
+      ],
+      "orcid": "0000-0002-5756-0223",
+      "directory_id": "athanasia-mo-mowinckel",
+      "email": "a.m.mowinckel@psykologi.uio.no"
+    },
+    {
+      "name": "Trym Nohr Fjørtoft",
+      "roles": [
+        "ctb"
+      ],
+      "orcid": "0000-0002-7654-4587"
+    }
+  ]
+}

--- a/data/packages/neuromapr.json
+++ b/data/packages/neuromapr.json
@@ -1,0 +1,23 @@
+{
+  "name": "neuromapr",
+  "title": "Spatial Null Models and Transforms for Brain Map Comparison",
+  "description": "Implements spatial null models and coordinate-space transformations for statistical comparison of brain maps, following the framework described in Markello et al. (2022) <doi:10.1038/s41592-022-01625-w>. Provides variogram-matching surrogates (Burt et al. 2020), Moran spectral randomization (Wagner & Dray 2015), and spin-based permutation tests (Alexander-Bloch et al. 2018). Includes an R interface to the 'neuromaps' annotation registry for browsing, downloading, and comparing brain map annotations from the Open Science Framework ('OSF'). Integrates with 'ciftiTools' for coordinate-space transforms.",
+  "repo_url": "https://github.com/lcbc-uio/neuromapr",
+  "pkdown_url": "https://lcbc-uio.github.io/neuromapr/",
+  "bug_reports_url": "https://github.com/lcbc-uio/neuromapr/issues",
+  "logo_url": "https://lcbc-uio.github.io/neuromapr/logo.svg",
+  "last_updated": "2026-04-30",
+  "authors": [
+    {
+      "name": "Athanasia Mo Mowinckel",
+      "roles": [
+        "aut",
+        "cre",
+        "cph"
+      ],
+      "orcid": "0000-0002-5756-0223",
+      "directory_id": "athanasia-mo-mowinckel",
+      "email": "a.m.mowinckel@psykologi.uio.no"
+    }
+  ]
+}

--- a/data/packages/palmerpenguins.json
+++ b/data/packages/palmerpenguins.json
@@ -22,7 +22,8 @@
       "roles": [
         "aut"
       ],
-      "orcid": "0000-0002-8082-1890"
+      "orcid": "0000-0002-8082-1890",
+      "directory_id": "alison-presmanes-hill"
     },
     {
       "name": "Kristen Gorman",


### PR DESCRIPTION
Adds 7 packages authored by Athanasia Monika Mowinckel.

| Package | r-universe handle | Logo |
|---|---|---|
| \`ggseg\` | ggsegverse | pkgdown |
| \`ggseg.extra\` | ggsegverse | README \`man/figures/logo.png\` |
| \`ggseg3d\` | ggsegverse | pkgdown |
| \`ggseg.formats\` | ggsegverse | none found |
| \`ggseg.meshes\` | ggsegverse | pkgdown |
| \`neuromapr\` | ggsegverse | pkgdown |
| \`nettskjemar\` | lcbc-uio | README \`man/figures/logo.png\` |

All metadata fetched via \`fetch_universe_package\` and shaped through the standard \`to_package_shape\` pipeline; the multi-stage logo probe from #171 caught all but \`ggseg.formats\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)