### PR TITLE
Collect directory IDs in the new-package issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-package.yaml
+++ b/.github/ISSUE_TEMPLATE/new-package.yaml
@@ -41,12 +41,30 @@ body:
     validations:
       required: false
   - type: textarea
+    id: directory_ids
+    attributes:
+      label: Directory IDs
+      description: |
+        If you (or co-authors) have an entry in the [R-Ladies directory](https://github.com/rladies/directory),
+        list one directory id per line so we can link the package to your profile(s).
+        Use the slug (filename without `.json`) from the directory.
+
+        Each line is either:
+        - `slug` — we'll match by name from the directory
+        - `slug = Author Name` — explicit pairing if your directory name doesn't match the package author exactly
+      placeholder: |
+        athanasia-mo-mowinckel
+        alejandra-tapia = Alejandra Tapia González
+      render: text
+    validations:
+      required: false
+  - type: textarea
     id: notes
     attributes:
       label: Additional notes
       description: |
-        Anything else maintainers should know — e.g. additional authors who
-        need a `directory_id`, a custom logo URL, etc.
+        Anything else maintainers should know — e.g. a custom logo URL, an
+        author whose name differs across CRAN/r-universe, etc.
     validations:
       required: false
   - type: checkboxes

--- a/.github/workflows/new-package-issue.yaml
+++ b/.github/workflows/new-package-issue.yaml
@@ -44,10 +44,12 @@ jobs:
             const pkg = fields['package name'] || '';
             const owner = fields['r-universe owner / github org or user'] || '';
             const repoUrl = fields['repository url'] || '';
+            const directoryIds = fields['directory ids'] || '';
             core.setOutput('pkg_name', pkg);
             core.setOutput('pkg_owner', owner);
             core.setOutput('pkg_repo_url', repoUrl);
-            core.info(`Parsed: name='${pkg}' owner='${owner}' repo='${repoUrl}'`);
+            core.setOutput('directory_ids', directoryIds);
+            core.info(`Parsed: name='${pkg}' owner='${owner}' repo='${repoUrl}' directory_ids='${directoryIds.replace(/\n/g, ' | ')}'`);
 
       - name: Bail out if package name is missing
         if: steps.parse.outputs.pkg_name == ''
@@ -82,6 +84,7 @@ jobs:
           PKG_NAME: ${{ steps.parse.outputs.pkg_name }}
           PKG_OWNER: ${{ steps.parse.outputs.pkg_owner }}
           PKG_REPO_URL: ${{ steps.parse.outputs.pkg_repo_url }}
+          DIRECTORY_IDS: ${{ steps.parse.outputs.directory_ids }}
         run: Rscript scripts/issue_to_package.R
 
       - name: Comment on lookup failure

--- a/scripts/discover_helpers.R
+++ b/scripts/discover_helpers.R
@@ -34,6 +34,33 @@ read_authors <- function(dir) {
   out
 }
 
+# Read directory entries that have a github handle, returning a list of
+# (slug, name, github) tuples. Used to seed package discovery for community
+# members who don't (yet) have a blog listed in data/content/.
+read_directory_entries <- function(dir) {
+  if (!dir.exists(dir)) {
+    return(list())
+  }
+  files <- list.files(dir, pattern = "\\.json$", full.names = TRUE)
+  out <- list()
+  for (f in files) {
+    entry <- tryCatch(jsonlite::read_json(f), error = function(e) NULL)
+    if (is.null(entry)) {
+      next
+    }
+    gh <- entry$social_media$github
+    if (is_blank(gh)) {
+      next
+    }
+    out[[length(out) + 1]] <- list(
+      slug = sub("\\.json$", "", basename(f)),
+      name = entry$name %||% NA_character_,
+      github = trimws(gh)
+    )
+  }
+  out
+}
+
 # Build a name/handle -> directory slug lookup from the sibling rladies/directory
 # repo. The slug (filename minus .json) is the canonical directory_id.
 build_directory_lookup <- function(dir) {
@@ -43,11 +70,12 @@ build_directory_lookup <- function(dir) {
       normalizePath(dir, mustWork = FALSE),
       " — directory_id lookup will be skipped."
     )
-    return(list(by_handle = list(), by_name = list()))
+    return(list(by_handle = list(), by_name = list(), by_slug = list()))
   }
   files <- list.files(dir, pattern = "\\.json$", full.names = TRUE)
   by_handle <- list()
   by_name <- list()
+  by_slug <- list()
   for (f in files) {
     entry <- tryCatch(jsonlite::read_json(f), error = function(e) NULL)
     if (is.null(entry)) {
@@ -60,10 +88,117 @@ build_directory_lookup <- function(dir) {
     }
     if (!is_blank(entry$name)) {
       by_name[[tolower(trimws(ascii(entry$name)))]] <- id
+      by_slug[[tolower(id)]] <- entry$name
     }
   }
   message("Loaded ", length(files), " directory entries from ", dir)
-  list(by_handle = by_handle, by_name = by_name)
+  list(by_handle = by_handle, by_name = by_name, by_slug = by_slug)
+}
+
+# Parse a "Directory IDs" textarea from the issue form. Each non-blank line is
+# either:
+#   - bare `slug` (we'll resolve the name from the directory entry)
+#   - `Author Name = slug` or `slug = Author Name` (explicit pairing for cases
+#     where the directory name doesn't quite match the package's Author field)
+# Returns a list of (slug, dir_name, explicit_name) entries; lines whose slug
+# isn't in the directory are dropped with a warning.
+parse_directory_id_pairs <- function(text, dir_lookup) {
+  if (is_blank(text)) {
+    return(list())
+  }
+  lines <- trimws(strsplit(text, "[\r\n]+")[[1]])
+  lines <- lines[nzchar(lines)]
+  pairs <- list()
+  for (line in lines) {
+    if (grepl("=", line, fixed = TRUE)) {
+      halves <- trimws(strsplit(line, "=", fixed = TRUE)[[1]])
+      a <- halves[1]
+      b <- if (length(halves) >= 2) halves[2] else ""
+      # Slug-shaped halves are lowercase letters/digits/hyphens only.
+      if (grepl("^[a-z0-9-]+$", a)) {
+        slug <- a
+        explicit_name <- b
+      } else {
+        slug <- b
+        explicit_name <- a
+      }
+    } else {
+      slug <- line
+      explicit_name <- ""
+    }
+    slug <- tolower(trimws(slug))
+    if (!nzchar(slug)) {
+      next
+    }
+    dir_name <- dir_lookup$by_slug[[slug]]
+    if (is.null(dir_name)) {
+      message(
+        "Directory id '",
+        slug,
+        "' not found in the R-Ladies directory — skipping."
+      )
+      next
+    }
+    pairs[[length(pairs) + 1]] <- list(
+      slug = slug,
+      dir_name = dir_name,
+      explicit_name = explicit_name
+    )
+  }
+  pairs
+}
+
+# Two names match if either is contained in the other (substring), or if
+# their first and last tokens are identical, after ascii/case normalisation.
+# Token comparison handles common DESCRIPTION quirks like missing middle
+# names ("Athanasia Mo Mowinckel" vs "Athanasia Mowinckel").
+names_match <- function(a, b) {
+  if (is_blank(a) || is_blank(b)) {
+    return(FALSE)
+  }
+  if (name_in(a, b) || name_in(b, a)) {
+    return(TRUE)
+  }
+  ta <- strsplit(tolower(trimws(ascii(a))), "\\s+")[[1]]
+  tb <- strsplit(tolower(trimws(ascii(b))), "\\s+")[[1]]
+  ta <- ta[nzchar(ta)]
+  tb <- tb[nzchar(tb)]
+  if (length(ta) < 2 || length(tb) < 2) {
+    return(FALSE)
+  }
+  ta[1] == tb[1] && ta[length(ta)] == tb[length(tb)]
+}
+
+apply_directory_id_pairs <- function(authors, pairs) {
+  if (length(pairs) == 0) {
+    return(authors)
+  }
+  for (p in pairs) {
+    matched <- FALSE
+    candidates <- c(p$dir_name, if (nzchar(p$explicit_name)) p$explicit_name)
+    for (i in seq_along(authors)) {
+      if (any(vapply(
+        candidates,
+        function(c) names_match(c, authors[[i]]$name),
+        logical(1)
+      ))) {
+        authors[[i]]$directory_id <- p$slug
+        matched <- TRUE
+        break
+      }
+    }
+    if (!matched) {
+      message(
+        "Could not match directory_id '",
+        p$slug,
+        "' (",
+        p$dir_name,
+        ") to any package author. ",
+        "Add `slug = Author Name` in the form to override the matching name."
+      )
+    }
+  }
+  authors
 }
 
 lookup_directory_id <- function(name, github, dir_lookup) {

--- a/scripts/issue_to_package.R
+++ b/scripts/issue_to_package.R
@@ -20,6 +20,7 @@ env_or_arg <- function(env_name, arg_index) {
 pkg_name <- trimws(env_or_arg("PKG_NAME", 1))
 owner_hint <- trimws(env_or_arg("PKG_OWNER", 2))
 repo_url_hint <- trimws(env_or_arg("PKG_REPO_URL", 3))
+directory_ids_text <- env_or_arg("DIRECTORY_IDS", 4)
 
 if (!nzchar(pkg_name)) {
   stop("Package name is required (env PKG_NAME or first positional arg).")
@@ -107,6 +108,17 @@ if (is_blank(cand$url) && nzchar(repo_url_hint)) {
 }
 
 entry <- to_package_shape(cand, dir_lookup)
+
+# Apply explicit directory_id pairings from the issue form. These run after
+# the automatic name/handle lookup so submitters can fix mismatches that the
+# directory's own data doesn't catch (e.g. CRAN packages where the Author
+# field has a different transliteration of someone's name).
+pairs <- parse_directory_id_pairs(directory_ids_text, dir_lookup)
+if (length(pairs) > 0) {
+  cat("Applying", length(pairs), "directory_id pairings from the form\n")
+  entry$authors <- apply_directory_id_pairs(entry$authors, pairs)
+}
+
 path <- write_pkg(entry, packages_dir)
 
 cat("Wrote", path, "\n")


### PR DESCRIPTION
## Summary

Follow-up to #174. The CRAN fallback in `scripts/issue_to_package.R` already handles "package isn't on r-universe" — verified locally that `PKG_NAME=gtsummary` (no owner) produces a valid `data/packages/gtsummary.json`. But CRAN-only packages have no GitHub handle, so the automatic `directory_id` matching often misses.

This adds an optional **Directory IDs** textarea to the issue form so submitters can list the R-Ladies directory slugs for themselves and co-authors. The R script applies them after generating the package entry.

Form syntax (one per line):

```
athanasia-mo-mowinckel
alejandra-tapia = Alejandra Tapia González
```

- Bare slug → look up the canonical directory name and match a package author by token comparison (so e.g. `Athanasia Mo Mowinckel` from the directory matches `Athanasia Mowinckel` in a CRAN package's Author field via first/last-name agreement).
- `slug = Author Name` → explicit override when the directory name doesn't match the form in the package's Author field at all.
- Slugs not in the directory are dropped with a warning.

Plumbing:

- `parse_directory_id_pairs` and `apply_directory_id_pairs` added to `scripts/discover_helpers.R`, plus a `by_slug` map on `build_directory_lookup` and a token-aware `names_match`.
- `scripts/issue_to_package.R` reads `DIRECTORY_IDS` from env, applies pairs after `to_package_shape`.
- `.github/workflows/new-package-issue.yaml` parses the new form field and forwards it via env.

## Test plan

- [ ] Open a test issue for a CRAN-only package (e.g. `gtsummary`) without filling Directory IDs and confirm the bot still creates a JSON via the CRAN fallback.
- [ ] Open another issue with `Directory IDs` filled in (mix of bare slugs and `slug = Name` lines) and confirm the generated JSON has `directory_id` set on the matched authors.
- [ ] Submit a bogus slug and confirm the workflow comment / generated file silently drops it (the slug isn't injected into the JSON).
- [ ] Verify the issue body parser still picks up Package Name when the Directory IDs field is filled in (heading order matters for the regex).