### PR TITLE
Use existing package-submission label for new-package issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-package.yaml
+++ b/.github/ISSUE_TEMPLATE/new-package.yaml
@@ -1,7 +1,7 @@
 name: New Package
 description: Submit an R package authored by an R-Ladies community member
 title: "[New Package]: "
-labels: ["new-package"]
+labels: ["package-submission"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/new-package-issue.yaml
+++ b/.github/workflows/new-package-issue.yaml
@@ -16,8 +16,8 @@ concurrency:
 jobs:
   generate:
     if: |
-      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'new-package')) ||
-      (github.event.action == 'labeled' && github.event.label.name == 'new-package')
+      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'package-submission')) ||
+      (github.event.action == 'labeled' && github.event.label.name == 'package-submission')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -61,7 +61,7 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: "Hi @" + context.payload.issue.user.login +
-                ", I couldn't find a **Package Name** in the form — could you edit the issue to fill that field in? Once it's set I'll re-run automatically when the `new-package` label is re-applied."
+                ", I couldn't find a **Package Name** in the form — could you edit the issue to fill that field in? Once it's set I'll re-run automatically when the `package-submission` label is re-applied."
             });
             core.setFailed('Package name missing.');
 
@@ -105,7 +105,7 @@ jobs:
                 ", I couldn't find **`" + pkg + "`** on r-universe (owner: `" +
                 (owner || '<none>') + "`) or CRAN. " +
                 "Please double-check the package name and the r-universe owner, " +
-                "then remove and re-apply the `new-package` label to retry."
+                "then remove and re-apply the `package-submission` label to retry."
             });
 
       - name: Check for changes and prepare branch


### PR DESCRIPTION
## Summary

Issue #176 (the first real test of the form) opened with no labels because the form declared `labels: [\"new-package\"]` but that label doesn't exist in the repo — GitHub silently drops unknown labels at issue creation. The workflow's guard then didn't match and the action was skipped.

The repo already has a `package-submission` label whose description is literally "Auto-submitted package metadata via issue form", so this PR points the form and the workflow at that label.

## Test plan

- [ ] Once merged, manually add the `package-submission` label to #176 to trigger the workflow against that issue.
- [ ] Open a fresh test issue and confirm the label is auto-applied and the workflow runs end-to-end.