### PR TITLE
Fix Trigger Website workflow failing on fork PRs

### DIFF
--- a/.github/workflows/trigger-website.yaml
+++ b/.github/workflows/trigger-website.yaml
@@ -2,7 +2,7 @@ name: Trigger Website
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     branches:
       - main
 
@@ -36,7 +36,7 @@ jobs:
                 const path = require('path');
                 await github.rest.issues.createComment({
                     owner: 'rladies',
-                    repo: 'awesome-rladies-blogs',
+                    repo: '${{ github.event.repository.name }}',
                     issue_number: '${{ github.event.pull_request.number }}',
                     body: 'Building test-site now! The build will take a few minutes, but look at its progress in the [website repo](https://github.com/rladies/rladies.github.io/actions/workflows/build-preview.yaml).'
                 })


### PR DESCRIPTION
## Summary

The Trigger Website workflow has been failing on every PR from a fork (including all 5 of the directory-based pilot PRs #182-#186).

**Root cause:** the workflow uses `pull_request`, which doesn't pass repository secrets to runs that originate from a fork. So `secrets.GLOBAL_GHA_PAT` is empty, and the "Trigger test build" step errors with `Input required and not supplied: github-token`.

**Latent bug also fixed:** the "Notify about build start" step still hardcoded `repo: 'awesome-rladies-blogs'` (the old repo name pre-rename), which would 404 even if the trigger step succeeded.

## Changes

- `pull_request` → `pull_request_target`. This is safe here because the job only calls APIs with constants and event payload values; it doesn't check out PR code or execute anything from the fork.
- `repo: 'awesome-rladies-blogs'` → `repo: '${{ github.event.repository.name }}'` so the notify step targets the current repo regardless of future renames (mirrors how `triggering_repo` is already passed to the upstream build).

## Test plan

- [ ] Once merged, future fork PRs (or a manual `workflow_dispatch`) should fire the trigger step without error.
- [ ] The "Notify about build start" comment should land on the PR in `rladies/awesome-rladies-creations`.
- [ ] Re-trigger one of the pilot PRs (#182-#186) by pushing a no-op commit to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)