### PR TITLE
Close issue and assign author when auto-PR opens

### DIFF
--- a/.github/workflows/new-package-issue.yaml
+++ b/.github/workflows/new-package-issue.yaml
@@ -194,6 +194,7 @@ jobs:
             });
 
             let pr;
+            let prCreated = false;
             if (existing.data.length > 0) {
               pr = existing.data[0];
               await github.rest.pulls.update({
@@ -214,12 +215,37 @@ jobs:
                 draft: true
               });
               pr = created.data;
+              prCreated = true;
               core.info(`Opened PR #${pr.number}`);
+            }
+
+            // Assign the issue author to the PR so it shows up on their dashboard.
+            // Silently no-ops for users without write access (GitHub ignores them).
+            try {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                assignees: [author]
+              });
+            } catch (e) {
+              core.info(`Could not assign @${author} to PR #${pr.number}: ${e.message}`);
             }
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
-              body: `Hi @${author}, I drafted [\`${file}\`](${pr.html_url}/files) on branch \`${branch}\` and opened ${pr.html_url} for review. Take a look and request adjustments on the PR — the file is generated from \`${source}\` so things like additional authors' \`directory_id\` may need a manual touch-up.`
+              body: `Hi @${author}, I drafted [\`${file}\`](${pr.html_url}/files) on branch \`${branch}\` and opened ${pr.html_url} for review. Take a look and request adjustments on the PR — the file is generated from \`${source}\` so things like additional authors' \`directory_id\` may need a manual touch-up. I'm closing this issue; let's continue on the PR.`
             });
+
+            // Move communication to the PR by closing the issue once the PR is up.
+            // Only on first creation — if a maintainer reopened the issue, leave it.
+            if (prCreated) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                state: 'closed'
+              });
+            }


### PR DESCRIPTION
## Summary

Once the new-package-issue bot opens the draft PR, the issue is redundant — review comments belong on the PR (where reviewers can quote the diff). This change moves the conversation cleanly:

- **Closes the originating issue** as soon as the PR is first opened.
- **Assigns the issue author to the PR** so it appears on their dashboard and they get notified.

## Behaviour notes

- Close happens only on first PR creation (`prCreated` guard). If the bot re-runs (e.g. label re-applied) and finds an existing PR, it just updates the body — doesn't re-close the issue. This preserves a maintainer's choice to reopen.
- `addAssignees` silently ignores users who can't be assigned (i.e. non-collaborators), so the step works regardless of the issue author's permission level. Wrapped in try/catch as a belt-and-braces against unexpected 422s.
- The existing PR-link comment on the issue now mentions the issue is being closed, so the user understands what just happened.
- Same change should land on the new-content workflow once #179 merges (separate follow-up).

## Test plan

- [ ] Open a test issue with the `package-submission` label and verify: PR opens, issue closes, issue author is shown as PR assignee, issue receives the bot's link-comment.
- [ ] Re-apply the label and verify the bot updates the existing PR without re-closing the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)