### PR TITLE
Extend package discovery to Bioconductor

### DIFF
--- a/scripts/discover_for_author.R
+++ b/scripts/discover_for_author.R
@@ -1,0 +1,118 @@
+#!/usr/bin/env Rscript
+# Run package discovery for a single author and write candidate package JSON
+# files into data/packages_pending/<slug>/. Useful when an author replies to a
+# directory PR and asks for additional packages we missed (e.g. Bioconductor
+# packages, packages where they're an author but not the maintainer).
+#
+# Usage:
+#   Rscript scripts/discover_for_author.R <slug> "<Author Name>" <github_handle>
+#
+# Example:
+#   Rscript scripts/discover_for_author.R susan-holmes "Susan Holmes" spholmes
+
+suppressPackageStartupMessages(library(here))
+source(here::here("scripts", "discover_helpers.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 3) {
+  stop(
+    "Usage: Rscript scripts/discover_for_author.R <slug> \"<Author Name>\" <github_handle>",
+    call. = FALSE
+  )
+}
+slug <- args[[1]]
+author_name <- args[[2]]
+github_handle <- args[[3]]
+
+pending_dir <- here::here("data", "packages_pending", slug)
+directory_dir <- here::here("..", "directory", "data", "json")
+
+dir_lookup <- build_directory_lookup(directory_dir)
+
+a <- list(name = author_name, github = github_handle)
+candidates <- list()
+
+cat("R-universe lookup for handle:", a$github, "\n")
+pkgs <- fetch_universe(a$github)
+if (!is.null(pkgs)) {
+  for (p in pkgs) {
+    is_owner <- owner_match(p, a$github)
+    name_hit <- name_in(a$name, p$Maintainer) || name_in(a$name, p$Author)
+    if (!is_owner && !name_hit) next
+    if (!is_owner && !is_authorship(a$name, p$Author, p$Maintainer)) next
+    roles <- roles_for(a$name, p$Author)
+    if (length(roles) == 0) roles <- "owner"
+    candidates[[length(candidates) + 1]] <-
+      normalise_pkg(p, "r-universe", a$name, a$github, paste(roles, collapse = ","))
+  }
+}
+cat("  ", length(candidates), "candidates after r-universe\n")
+
+cat("CRAN lookup...\n")
+cran <- tryCatch(tools::CRAN_package_db(), error = function(e) NULL)
+if (!is.null(cran)) {
+  hits <- which(
+    vapply(cran$Author, function(s) name_in(a$name, s), logical(1)) |
+      vapply(cran$Maintainer, function(s) name_in(a$name, s), logical(1))
+  )
+  for (i in hits) {
+    row <- cran[i, ]
+    if (!is_authorship(a$name, row$Author, row$Maintainer)) next
+    roles <- paste(roles_for(a$name, row$Author), collapse = ",")
+    candidates[[length(candidates) + 1]] <- list(
+      package = row$Package,
+      title = row$Title,
+      description = trimws(gsub("\\s+", " ", row$Description %||% "")),
+      repo_owner = NA_character_,
+      url = row$URL,
+      bug_reports = row$BugReports,
+      maintainer = row$Maintainer,
+      last_updated = to_iso_date(row[["Date/Publication"]]),
+      authors = parse_authors(row$Author),
+      matched_author = a$name,
+      matched_handle = a$github,
+      matched_roles = roles,
+      source = "cran"
+    )
+  }
+}
+cat("  ", length(candidates), "candidates after CRAN\n")
+
+cat("Bioconductor lookup (bioc.r-universe.dev)...\n")
+bioc <- tryCatch(fetch_bioc_db(), error = function(e) NULL)
+if (!is.null(bioc)) {
+  for (p in bioc) {
+    name_hit <- name_in(a$name, p$Maintainer) || name_in(a$name, p$Author)
+    if (!name_hit) next
+    if (!is_authorship(a$name, p$Author, p$Maintainer)) next
+    roles <- roles_for(a$name, p$Author)
+    if (length(roles) == 0) roles <- "unknown"
+    candidates[[length(candidates) + 1]] <-
+      normalise_pkg(p, "bioconductor", a$name, a$github, paste(roles, collapse = ","))
+  }
+}
+cat("  ", length(candidates), "candidates after Bioconductor\n")
+
+dedup_key <- vapply(candidates, function(x) tolower(x$package %||% ""), character(1))
+candidates <- candidates[!duplicated(dedup_key) & nzchar(dedup_key)]
+candidates <- Filter(function(x) !(is_blank(x$title) && is_blank(x$description)), candidates)
+cat("After dedupe and dropping unbuilt packages:", length(candidates), "\n")
+
+if (!dir.exists(pending_dir)) {
+  dir.create(pending_dir, recursive = TRUE)
+}
+
+for (cand in candidates) {
+  entry <- to_package_shape(cand, dir_lookup)
+  # Stamp the directory_id on the matched author so downstream tools can use it.
+  entry$authors <- lapply(entry$authors, function(p) {
+    if (names_match(p$name, author_name)) {
+      p$directory_id <- slug
+    }
+    p
+  })
+  path <- write_pkg(entry, pending_dir)
+  cat("  wrote", basename(path), "(source:", cand$source, ")\n")
+}
+
+cat("Done.", length(candidates), "package files in", pending_dir, "\n")

--- a/scripts/discover_helpers.R
+++ b/scripts/discover_helpers.R
@@ -264,6 +264,13 @@ fetch_universe_package <- function(owner, pkg) {
   )
 }
 
+# Bioconductor packages are mirrored at bioc.r-universe.dev with the same
+# fields as any other r-universe sub-universe, so we reuse the universe shape.
+# Returns a list of package metadata entries, one per Bioconductor package.
+fetch_bioc_db <- function() {
+  fetch_universe("bioc")
+}
+
 head_ok <- function(url) {
   h <- curl::new_handle()
   curl::handle_setopt(
@@ -571,17 +578,28 @@ to_package_shape <- function(cand, dir_lookup) {
 
   parsed <- cand$authors
   # Some old DESCRIPTION fields are role-less; if we know who the maintainer is
-  # from the Maintainer field but they're missing from Author, inject them.
+  # from the Maintainer field but they're missing from Author, attach "cre" to
+  # the matching entry. If the maintainer isn't in Author at all, append them.
   has_cre <- any(vapply(
     parsed,
     function(a) "cre" %in% unlist(a$roles),
     logical(1)
   ))
   if (!has_cre && !is.na(m$name)) {
-    parsed <- c(
+    match_idx <- which(vapply(
       parsed,
-      list(list(name = m$name, roles = list("cre"), orcid = NA_character_))
-    )
+      function(a) names_match(a$name, m$name),
+      logical(1)
+    ))
+    if (length(match_idx) > 0) {
+      idx <- match_idx[1]
+      parsed[[idx]]$roles <- as.list(unique(c(unlist(parsed[[idx]]$roles), "cre")))
+    } else {
+      parsed <- c(
+        parsed,
+        list(list(name = m$name, roles = list("cre"), orcid = NA_character_))
+      )
+    }
   }
 
   authors <- lapply(parsed, function(a) {

--- a/scripts/discover_packages.R
+++ b/scripts/discover_packages.R
@@ -90,6 +90,35 @@ if (!is.null(cran)) {
   }
 }
 
+cat("Fetching Bioconductor package db (bioc.r-universe.dev)...\n")
+bioc <- tryCatch(fetch_bioc_db(), error = function(e) NULL)
+if (!is.null(bioc) && length(bioc) > 0) {
+  cat("  ", length(bioc), "Bioconductor packages\n")
+  for (a in authors) {
+    for (p in bioc) {
+      name_hit <- name_in(a$name, p$Maintainer) || name_in(a$name, p$Author)
+      if (!name_hit) {
+        next
+      }
+      if (!is_authorship(a$name, p$Author, p$Maintainer)) {
+        next
+      }
+      roles <- roles_for(a$name, p$Author)
+      if (length(roles) == 0) {
+        roles <- "unknown"
+      }
+      candidates[[length(candidates) + 1]] <-
+        normalise_pkg(
+          p,
+          "bioconductor",
+          a$name,
+          a$github,
+          paste(roles, collapse = ",")
+        )
+    }
+  }
+}
+
 cat("Total raw candidate rows:", length(candidates), "\n")
 dedup_key <- vapply(
   candidates,


### PR DESCRIPTION
## Summary

- Extends `scripts/discover_packages.R` to match author/maintainer names against Bioconductor packages, in addition to the existing CRAN + r-universe checks. Bioconductor packages are mirrored at `bioc.r-universe.dev`, which conveniently exposes the same r-universe API shape.
- Adds `scripts/discover_for_author.R`, a small one-shot helper for re-running discovery for a single author. Useful when an author replies on a directory PR asking for additional packages we missed (e.g. Bioconductor packages, packages where they're an author but not the maintainer). Writes into `data/packages_pending/<slug>/`.
- Fixes a pre-existing duplicate-author bug in `to_package_shape()`: when the Maintainer matched a name already in the parsed Author list (no roles in DESCRIPTION), the helper appended a separate `cre` entry for the same person. Now it attaches `cre` to the existing entry instead.

Surfaced by an opt-in reply from Susan Holmes on #236, where she asked whether Bioconductor counted (her lab develops `phyloseq` and `dada2`).

## Test plan

- [ ] `Rscript scripts/discover_for_author.R susan-holmes "Susan Holmes" spholmes` writes `phyloseq.json`, `dada2.json`, `CyTOFpower.json`, `XICOR.json`, `distory.json` into `data/packages_pending/susan-holmes/`
- [ ] Same script for `erin-ledell` / `Erin LeDell` / `ledell` writes 7 files (cvAUC, h2o, h2o4gpu, rHealthDataGov, rsparkling, subsemble, SuperLearner)
- [ ] Spot-check: no duplicate author entries for the same person in the generated JSONs