### PR TITLE
Fix write_pkg serializing blank scalars as {} on rewrite

### DIFF
--- a/scripts/discover_helpers.R
+++ b/scripts/discover_helpers.R
@@ -654,6 +654,19 @@ write_pkg <- function(entry, dir) {
   path <- file.path(dir, paste0(entry$name, ".json"))
   existing <- if (file.exists(path)) jsonlite::read_json(path) else list()
   merged <- merge_pkg(existing, entry)
+  # Normalise scalar fields to NA_character_ when missing/NULL so write_json
+  # serialises them as `null` (per `na = "null"` below) rather than `{}`,
+  # which would otherwise happen on a read+rewrite cycle and fail schema
+  # validation (string|null fields can't be empty objects).
+  scalar_fields <- c(
+    "name", "title", "description", "repo_url",
+    "pkdown_url", "bug_reports_url", "logo_url", "last_updated"
+  )
+  for (f in scalar_fields) {
+    if (is.null(merged[[f]]) || length(merged[[f]]) == 0) {
+      merged[[f]] <- NA_character_
+    }
+  }
   if (!dir.exists(dir)) {
     dir.create(dir, recursive = TRUE)
   }


### PR DESCRIPTION
## Summary

`write_pkg()` reads any existing per-package JSON, merges new metadata in, and writes the result back. When a scalar field (e.g. `pkdown_url`, `bug_reports_url`, `logo_url`) was blank in both old and new, the merged list ended up with that key set to `NULL`. `jsonlite::write_json(..., na = \"null\")` only handles `NA`, not `NULL`, so the field round-tripped as \`{}\` (empty object) — which the schema rejects (`string | null`).

Fix: normalize all scalar fields back to `NA_character_` before writing, so `na = \"null\"` does the right thing.

Surfaced as failing schema validation on directory PRs after the rerun-discovery pass (e.g. #228, #210, #208, #202, #190 — already cleaned up in those branches with explicit `null` rewrites).

## Test plan

- [ ] On a fresh clone, run `Rscript scripts/discover_for_author.R` for an author with packages missing pkgdown sites. The resulting JSON should have `\"pkdown_url\": null`, not `\"pkdown_url\": {}`.
- [ ] Run discovery a second time; the file should still validate against `data/json_schema/packages.json`.