### PR TITLE
Trigger website only when data/ changes

### DIFF
--- a/.github/workflows/trigger-website.yaml
+++ b/.github/workflows/trigger-website.yaml
@@ -5,6 +5,9 @@ on:
   pull_request_target:
     branches:
       - main
+    paths:
+      - 'data/content/**'
+      - 'data/packages/**'
 
 jobs:
   trigger:


### PR DESCRIPTION
## Summary

Add a `paths` filter to the `Trigger Website` workflow so it (and the accompanying \"Building test-site now!\" PR comment) only runs on PRs that touch `data/content/**` or `data/packages/**`. PRs that change only scripts, workflows, or docs no longer kick off a website preview build — there's nothing data-shaped for it to render differently.

Mirrors the `paths` filter already on `Validate JSON metadata`.

## Test plan

- [ ] A PR that edits only `scripts/` (e.g. #243) does not trigger the website build or the comment.
- [ ] A PR that adds a file under `data/packages/` still triggers it.