### PR TITLE
Allow listing multiple packages in a single submission issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-package.yaml
+++ b/.github/ISSUE_TEMPLATE/new-package.yaml
@@ -1,42 +1,52 @@
 name: New Package
-description: Submit an R package authored by an R-Ladies community member
+description: Submit one or more R packages authored by R-Ladies community members
 title: "[New Package]: "
 labels: ["package-submission"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for submitting a new R package! :tada:
+        Thanks for submitting! :tada: You can list **one package per line** —
+        no need to open a separate issue for each.
 
-        Once you open this issue, a bot will try to look the package up on
-        r-universe and CRAN, generate a JSON file under `data/packages/`, push
-        it to a new branch, and open a draft pull request linked to this
-        issue. You'll be tagged on the PR so you can review the file (e.g.
-        adding `directory_id` for additional authors) before it is merged.
-  - type: input
-    id: package
+        Once you open this issue, a bot will look each package up on r-universe
+        and CRAN, generate a JSON file under `data/packages/`, push them to a
+        new branch, and open a single draft pull request linked to this issue.
+        You'll be tagged on the PR so you can review the files (e.g. adding
+        `directory_id` for additional authors) before they're merged.
+  - type: textarea
+    id: packages
     attributes:
-      label: Package Name
-      description: The package's `Package:` field, e.g. `meetupr`.
-      placeholder: ex. meetupr
+      label: Packages
+      description: |
+        One package per line. Each line is either:
+        - `pkg` — uses the default r-universe owner below (or CRAN as fallback)
+        - `pkg @ owner` — overrides the default owner for that package
+      placeholder: |
+        meetupr
+        praise @ rladies
+        myotherpkg @ someorg
+      render: text
     validations:
       required: true
   - type: input
     id: owner
     attributes:
-      label: R-universe Owner / GitHub Org or User
+      label: Default R-universe Owner / GitHub Org or User
       description: |
-        The r-universe namespace or GitHub user/org that hosts the package.
-        Used to query `https://<owner>.r-universe.dev`. If left empty we'll
-        fall back to CRAN.
+        Default r-universe namespace used for any line that doesn't specify
+        `@ owner`. Used to query `https://<owner>.r-universe.dev`. If left
+        empty we'll fall back to CRAN.
       placeholder: ex. rladies
     validations:
       required: false
   - type: input
     id: repo_url
     attributes:
-      label: Repository URL
-      description: GitHub/GitLab/Codeberg URL for the package source.
+      label: Repository URL (single-package only)
+      description: |
+        GitHub/GitLab/Codeberg URL for the package source. Only used when
+        you've listed exactly one package above — otherwise leave blank.
       placeholder: ex. https://github.com/rladies/meetupr
     validations:
       required: false
@@ -46,7 +56,8 @@ body:
       label: Directory IDs
       description: |
         If you (or co-authors) have an entry in the [R-Ladies directory](https://github.com/rladies/directory),
-        list one directory id per line so we can link the package to your profile(s).
+        list one directory id per line so we can link the package(s) to your
+        profile(s). These apply to **every** package in this issue.
         Use the slug (filename without `.json`) from the directory.
 
         Each line is either:

--- a/.github/workflows/new-package-issue.yaml
+++ b/.github/workflows/new-package-issue.yaml
@@ -39,20 +39,23 @@ jobs:
               const key = m[1].trim().toLowerCase();
               let value = (m[2] || '').trim();
               if (value === '_No response_') value = '';
+              // Strip ```text ... ``` fences that GitHub adds around `render: text`
+              // textareas so downstream parsers see the raw lines.
+              value = value.replace(/^```[a-z]*\s*\n?/i, '').replace(/\n?```\s*$/, '').trim();
               fields[key] = value;
             }
-            const pkg = fields['package name'] || '';
-            const owner = fields['r-universe owner / github org or user'] || '';
-            const repoUrl = fields['repository url'] || '';
+            const packages = fields['packages'] || '';
+            const owner = fields['default r-universe owner / github org or user'] || '';
+            const repoUrl = fields['repository url (single-package only)'] || '';
             const directoryIds = fields['directory ids'] || '';
-            core.setOutput('pkg_name', pkg);
+            core.setOutput('pkg_names', packages);
             core.setOutput('pkg_owner', owner);
             core.setOutput('pkg_repo_url', repoUrl);
             core.setOutput('directory_ids', directoryIds);
-            core.info(`Parsed: name='${pkg}' owner='${owner}' repo='${repoUrl}' directory_ids='${directoryIds.replace(/\n/g, ' | ')}'`);
+            core.info(`Parsed ${packages.split('\n').filter(Boolean).length} package line(s); owner='${owner}'`);
 
-      - name: Bail out if package name is missing
-        if: steps.parse.outputs.pkg_name == ''
+      - name: Bail out if no packages listed
+        if: steps.parse.outputs.pkg_names == ''
         uses: actions/github-script@v7
         with:
           script: |
@@ -61,9 +64,9 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: "Hi @" + context.payload.issue.user.login +
-                ", I couldn't find a **Package Name** in the form — could you edit the issue to fill that field in? Once it's set I'll re-run automatically when the `package-submission` label is re-applied."
+                ", I couldn't find any package names in the **Packages** field — could you edit the issue and list one package per line? Once it's set I'll re-run automatically when the `package-submission` label is re-applied."
             });
-            core.setFailed('Package name missing.');
+            core.setFailed('No packages listed.');
 
       - name: Install cURL headers
         run: |
@@ -78,10 +81,10 @@ jobs:
       - name: Setup renv
         uses: r-lib/actions/setup-renv@v2
 
-      - name: Generate package JSON
+      - name: Generate package JSON(s)
         id: generate
         env:
-          PKG_NAME: ${{ steps.parse.outputs.pkg_name }}
+          PKG_NAMES: ${{ steps.parse.outputs.pkg_names }}
           PKG_OWNER: ${{ steps.parse.outputs.pkg_owner }}
           PKG_REPO_URL: ${{ steps.parse.outputs.pkg_repo_url }}
           DIRECTORY_IDS: ${{ steps.parse.outputs.directory_ids }}
@@ -91,100 +94,129 @@ jobs:
         if: failure() && steps.generate.outcome == 'failure'
         uses: actions/github-script@v7
         env:
-          PKG_NAME: ${{ steps.parse.outputs.pkg_name }}
+          PKG_NAMES: ${{ steps.parse.outputs.pkg_names }}
           PKG_OWNER: ${{ steps.parse.outputs.pkg_owner }}
         with:
           script: |
-            const pkg = process.env.PKG_NAME;
-            const owner = process.env.PKG_OWNER;
+            const list = (process.env.PKG_NAMES || '')
+              .split('\n').map(l => l.trim()).filter(Boolean)
+              .map(l => '- `' + l + '`').join('\n');
+            const owner = process.env.PKG_OWNER || '<none>';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: "Hi @" + context.payload.issue.user.login +
-                ", I couldn't find **`" + pkg + "`** on r-universe (owner: `" +
-                (owner || '<none>') + "`) or CRAN. " +
-                "Please double-check the package name and the r-universe owner, " +
+                ", I couldn't find any of these packages on r-universe (default owner: `" +
+                owner + "`) or CRAN:\n\n" + list +
+                "\n\nPlease double-check the package names and r-universe owners, " +
                 "then remove and re-apply the `package-submission` label to retry."
             });
 
-      - name: Check for changes and prepare branch
-        id: branch
-        env:
-          FILE_PATH: ${{ steps.generate.outputs.file_path }}
-          PKG: ${{ steps.generate.outputs.package_name }}
-          ISSUE: ${{ github.event.issue.number }}
+      - name: Stage changes
+        id: stage
         run: |
           set -euo pipefail
-          branch="auto/new-package-${PKG}-${ISSUE}"
-          echo "branch=${branch}" >> "$GITHUB_OUTPUT"
-          echo "file=${FILE_PATH}" >> "$GITHUB_OUTPUT"
-          if git diff --quiet -- "$FILE_PATH" && ! git ls-files --others --exclude-standard --error-unmatch "$FILE_PATH" >/dev/null 2>&1; then
+          git add data/packages/
+          if git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
+          branch="auto/new-packages-${{ github.event.issue.number }}"
+          echo "branch=${branch}" >> "$GITHUB_OUTPUT"
 
       - name: Comment when nothing changed
-        if: steps.branch.outputs.changed == 'false'
+        if: steps.stage.outputs.changed == 'false'
         uses: actions/github-script@v7
-        env:
-          FILE_PATH: ${{ steps.branch.outputs.file }}
         with:
           script: |
-            const file = process.env.FILE_PATH;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: "Hi @" + context.payload.issue.user.login +
-                ", I looked the package up but `" + file + "` already matches the metadata on r-universe/CRAN — nothing to add. " +
-                "If something still needs changing, edit the file directly via a PR or describe the change here."
+                ", I looked the package(s) up but the data already matches what's on r-universe/CRAN — nothing to add. " +
+                "If something still needs changing, edit the file(s) directly via a PR or describe the change here."
             });
 
       - name: Push branch
-        if: steps.branch.outputs.changed == 'true'
+        if: steps.stage.outputs.changed == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: ${{ steps.branch.outputs.branch }}
-          FILE_PATH: ${{ steps.branch.outputs.file }}
-          PKG: ${{ steps.generate.outputs.package_name }}
+          BRANCH: ${{ steps.stage.outputs.branch }}
           ISSUE: ${{ github.event.issue.number }}
+          PKG_NAMES_OUT: ${{ steps.generate.outputs.package_names }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add "$FILE_PATH"
-          git commit -m "Add ${PKG} (issue #${ISSUE})"
+          count=$(printf '%s\n' "$PKG_NAMES_OUT" | grep -c . || true)
+          if [ "$count" = "1" ]; then
+            msg="Add ${PKG_NAMES_OUT} (issue #${ISSUE})"
+          else
+            msg="Add ${count} packages (issue #${ISSUE})"
+          fi
+          git commit -m "$msg"
           git push --force-with-lease origin "$BRANCH"
 
       - name: Open or update draft PR
-        if: steps.branch.outputs.changed == 'true'
+        if: steps.stage.outputs.changed == 'true'
         uses: actions/github-script@v7
         env:
-          BRANCH: ${{ steps.branch.outputs.branch }}
-          FILE_PATH: ${{ steps.branch.outputs.file }}
-          PKG: ${{ steps.generate.outputs.package_name }}
-          SOURCE: ${{ steps.generate.outputs.source }}
+          BRANCH: ${{ steps.stage.outputs.branch }}
+          PKG_NAMES_OUT: ${{ steps.generate.outputs.package_names }}
+          FILE_PATHS: ${{ steps.generate.outputs.file_paths }}
+          SOURCES: ${{ steps.generate.outputs.sources }}
+          FAILED: ${{ steps.generate.outputs.failed }}
         with:
           script: |
             const branch = process.env.BRANCH;
-            const file = process.env.FILE_PATH;
-            const pkg = process.env.PKG;
-            const source = process.env.SOURCE;
+            const pkgs = (process.env.PKG_NAMES_OUT || '').split('\n').filter(Boolean);
+            const files = (process.env.FILE_PATHS || '').split('\n').filter(Boolean);
+            const sources = (process.env.SOURCES || '').split('\n').filter(Boolean);
+            const failed = (process.env.FAILED || '').split('\n').filter(Boolean);
             const issueNumber = context.issue.number;
             const author = context.payload.issue.user.login;
 
-            const body = [
+            const sourceMap = Object.fromEntries(
+              sources.map(s => {
+                const i = s.indexOf('=');
+                return i === -1 ? [s, '?'] : [s.slice(0, i), s.slice(i + 1)];
+              })
+            );
+
+            const rows = pkgs.map((p, i) =>
+              `- **\`${p}\`** — \`${files[i] || '?'}\` (from \`${sourceMap[p] || '?'}\`)`
+            ).join('\n');
+
+            const title = pkgs.length === 1
+              ? `Add ${pkgs[0]} (issue #${issueNumber})`
+              : `Add ${pkgs.length} packages (issue #${issueNumber})`;
+
+            const bodyParts = [
               `Auto-generated from #${issueNumber}.`,
               ``,
-              `Pulled metadata for **\`${pkg}\`** from \`${source}\` and wrote it to \`${file}\`.`,
+              pkgs.length === 1
+                ? `Pulled metadata for the package below and wrote it to the listed file.`
+                : `Pulled metadata for ${pkgs.length} packages and wrote them to the listed files.`,
               ``,
-              `@${author} please review the file and request edits in this PR if anything is wrong (e.g. additional authors who need \`directory_id\`, missing logo, wrong description).`,
+              rows,
+              ``
+            ];
+            if (failed.length > 0) {
+              bodyParts.push(
+                `> :warning: Could not look up the following — please open a follow-up issue or comment with corrections:`,
+                failed.map(f => `> - \`${f}\``).join('\n'),
+                ``
+              );
+            }
+            bodyParts.push(
+              `@${author} please review the file(s) and request edits in this PR if anything is wrong (e.g. additional authors who need \`directory_id\`, missing logo, wrong description).`,
               ``,
               `Closes #${issueNumber}.`
-            ].join('\n');
+            );
+            const body = bodyParts.join('\n');
 
             const existing = await github.rest.pulls.list({
               owner: context.repo.owner,
@@ -201,6 +233,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: pr.number,
+                title,
                 body
               });
               core.info(`Updated existing PR #${pr.number}`);
@@ -208,7 +241,7 @@ jobs:
               const created = await github.rest.pulls.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: `Add ${pkg} (issue #${issueNumber})`,
+                title,
                 head: branch,
                 base: context.payload.repository.default_branch,
                 body,
@@ -219,8 +252,6 @@ jobs:
               core.info(`Opened PR #${pr.number}`);
             }
 
-            // Assign the issue author to the PR so it shows up on their dashboard.
-            // Silently no-ops for users without write access (GitHub ignores them).
             try {
               await github.rest.issues.addAssignees({
                 owner: context.repo.owner,
@@ -232,15 +263,19 @@ jobs:
               core.info(`Could not assign @${author} to PR #${pr.number}: ${e.message}`);
             }
 
+            const summary = pkgs.length === 1
+              ? `\`${pkgs[0]}\``
+              : `${pkgs.length} packages`;
+            const failNote = failed.length > 0
+              ? ` (${failed.length} couldn't be looked up — see PR description)`
+              : '';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
-              body: `Hi @${author}, I drafted [\`${file}\`](${pr.html_url}/files) on branch \`${branch}\` and opened ${pr.html_url} for review. Take a look and request adjustments on the PR — the file is generated from \`${source}\` so things like additional authors' \`directory_id\` may need a manual touch-up. I'm closing this issue; let's continue on the PR.`
+              body: `Hi @${author}, I drafted ${summary}${failNote} on branch \`${branch}\` and opened ${pr.html_url} for review. Take a look and request adjustments on the PR — fields like additional authors' \`directory_id\` may need a manual touch-up. I'm closing this issue; let's continue on the PR.`
             });
 
-            // Move communication to the PR by closing the issue once the PR is up.
-            // Only on first creation — if a maintainer reopened the issue, leave it.
             if (prCreated) {
               await github.rest.issues.update({
                 owner: context.repo.owner,

--- a/scripts/issue_to_package.R
+++ b/scripts/issue_to_package.R
@@ -6,8 +6,6 @@ source(here::here("scripts", "discover_helpers.R"))
 packages_dir <- here::here("data/packages")
 directory_dir <- here::here("..", "directory", "data", "json")
 
-# Inputs come from env vars set by the calling workflow. Falling back to
-# commandArgs makes the script convenient to invoke locally.
 env_or_arg <- function(env_name, arg_index) {
   v <- Sys.getenv(env_name, unset = "")
   if (nzchar(v)) {
@@ -17,61 +15,63 @@ env_or_arg <- function(env_name, arg_index) {
   if (length(args) >= arg_index) args[arg_index] else ""
 }
 
-pkg_name <- trimws(env_or_arg("PKG_NAME", 1))
-owner_hint <- trimws(env_or_arg("PKG_OWNER", 2))
-repo_url_hint <- trimws(env_or_arg("PKG_REPO_URL", 3))
-directory_ids_text <- env_or_arg("DIRECTORY_IDS", 4)
-
-if (!nzchar(pkg_name)) {
-  stop("Package name is required (env PKG_NAME or first positional arg).")
-}
-
-cat("Looking up package:", pkg_name, "\n")
-if (nzchar(owner_hint)) cat("  with owner hint:", owner_hint, "\n")
-if (nzchar(repo_url_hint)) cat("  with repo url hint:", repo_url_hint, "\n")
-
-# If we got a github URL but no explicit owner, pull owner out of the URL so
-# we can hit the right r-universe namespace.
-if (!nzchar(owner_hint) && nzchar(repo_url_hint)) {
-  owner_repo <- github_owner_repo(repo_url_hint)
-  if (!is.na(owner_repo)) {
-    owner_hint <- strsplit(owner_repo, "/", fixed = TRUE)[[1]][1]
-    cat("  derived owner from repo URL:", owner_hint, "\n")
+# Each line of the textarea is either `pkg` or `pkg @ owner`. Owners on a line
+# override the default; lines with no owner inherit `default_owner`.
+parse_package_lines <- function(text, default_owner) {
+  if (is_blank(text)) {
+    return(list())
   }
-}
-
-dir_lookup <- build_directory_lookup(directory_dir)
-
-cand <- NULL
-
-# 1. R-universe (under the requested owner) is the richest source: gives us
-#    the rebuilt DESCRIPTION fields plus _owner and Date/Publication.
-if (nzchar(owner_hint)) {
-  cat("Querying r-universe for", owner_hint, "/", pkg_name, "...\n")
-  pkg <- fetch_universe_package(owner_hint, pkg_name)
-  if (!is.null(pkg) && !is_blank(pkg$Package)) {
-    cand <- normalise_pkg(
-      pkg,
-      "r-universe",
-      pkg$Maintainer %||% NA_character_,
-      owner_hint,
-      NA_character_
-    )
-    cat("  found in r-universe\n")
-  } else {
-    cat("  not found in r-universe\n")
+  lines <- trimws(strsplit(text, "[\r\n]+")[[1]])
+  lines <- lines[nzchar(lines)]
+  out <- list()
+  for (line in lines) {
+    if (grepl("@", line, fixed = TRUE)) {
+      halves <- trimws(strsplit(line, "@", fixed = TRUE)[[1]])
+      pkg <- halves[1]
+      owner <- if (length(halves) >= 2) halves[2] else ""
+    } else {
+      pkg <- line
+      owner <- default_owner
+    }
+    if (!nzchar(pkg)) next
+    out[[length(out) + 1]] <- list(name = pkg, owner = owner)
   }
+  out
 }
 
-# 2. CRAN fallback when r-universe didn't have it. Cheaper to call once than
-#    to retry under guessed owners.
-if (is.null(cand)) {
-  cat("Falling back to CRAN package db...\n")
-  cran <- tryCatch(tools::CRAN_package_db(), error = function(e) NULL)
-  if (!is.null(cran)) {
-    hit <- which(tolower(cran$Package) == tolower(pkg_name))
+lookup_one <- function(pkg_name, owner_hint, repo_url_hint, cran_db) {
+  if (!nzchar(owner_hint) && nzchar(repo_url_hint)) {
+    owner_repo <- github_owner_repo(repo_url_hint)
+    if (!is.na(owner_repo)) {
+      owner_hint <- strsplit(owner_repo, "/", fixed = TRUE)[[1]][1]
+      cat("  derived owner from repo URL:", owner_hint, "\n")
+    }
+  }
+
+  cand <- NULL
+
+  if (nzchar(owner_hint)) {
+    cat("Querying r-universe for", owner_hint, "/", pkg_name, "...\n")
+    pkg <- fetch_universe_package(owner_hint, pkg_name)
+    if (!is.null(pkg) && !is_blank(pkg$Package)) {
+      cand <- normalise_pkg(
+        pkg,
+        "r-universe",
+        pkg$Maintainer %||% NA_character_,
+        owner_hint,
+        NA_character_
+      )
+      cat("  found in r-universe\n")
+    } else {
+      cat("  not found in r-universe\n")
+    }
+  }
+
+  if (is.null(cand) && !is.null(cran_db)) {
+    cat("Falling back to CRAN package db...\n")
+    hit <- which(tolower(cran_db$Package) == tolower(pkg_name))
     if (length(hit) > 0) {
-      row <- cran[hit[1], ]
+      row <- cran_db[hit[1], ]
       cand <- list(
         package = row$Package,
         title = row$Title,
@@ -92,52 +92,151 @@ if (is.null(cand)) {
       cat("  not found on CRAN\n")
     }
   }
+
+  if (is.null(cand)) {
+    return(NULL)
+  }
+
+  if (is_blank(cand$url) && nzchar(repo_url_hint)) {
+    cand$url <- repo_url_hint
+  }
+
+  cand
 }
 
-if (is.null(cand)) {
-  stop(sprintf(
-    "Could not find package '%s' in r-universe (owner: %s) or CRAN.",
-    pkg_name,
-    if (nzchar(owner_hint)) owner_hint else "<none>"
-  ))
+write_gha_output <- function(key, value, gha_out) {
+  if (!nzchar(gha_out)) return(invisible())
+  delim <- paste0("EOF_", key, "_", as.integer(Sys.time()))
+  lines <- c(
+    paste0(key, "<<", delim),
+    if (length(value) > 0) value else character(0),
+    delim
+  )
+  con <- file(gha_out, open = "a")
+  on.exit(close(con), add = TRUE)
+  writeLines(lines, con)
 }
 
-# Honour an explicit repo URL hint when r-universe/CRAN didn't surface one.
-if (is_blank(cand$url) && nzchar(repo_url_hint)) {
-  cand$url <- repo_url_hint
+pkg_names_text <- env_or_arg("PKG_NAMES", 1)
+default_owner <- trimws(env_or_arg("PKG_OWNER", 2))
+repo_url_hint <- trimws(env_or_arg("PKG_REPO_URL", 3))
+directory_ids_text <- env_or_arg("DIRECTORY_IDS", 4)
+
+requests <- parse_package_lines(pkg_names_text, default_owner)
+if (length(requests) == 0) {
+  stop("No package names provided (env PKG_NAMES).")
 }
 
-entry <- to_package_shape(cand, dir_lookup)
+# repo_url hint only makes sense for a single package.
+if (length(requests) > 1 && nzchar(repo_url_hint)) {
+  cat(
+    "Note: repository URL hint is ignored when more than one package is",
+    "submitted in the same issue.\n"
+  )
+  repo_url_hint <- ""
+}
 
-# Apply explicit directory_id pairings from the issue form. These run after
-# the automatic name/handle lookup so submitters can fix mismatches that the
-# directory's own data doesn't catch (e.g. CRAN packages where the Author
-# field has a different transliteration of someone's name).
+cat("Processing", length(requests), "package(s)\n")
+
+dir_lookup <- build_directory_lookup(directory_dir)
 pairs <- parse_directory_id_pairs(directory_ids_text, dir_lookup)
-if (length(pairs) > 0) {
-  cat("Applying", length(pairs), "directory_id pairings from the form\n")
-  entry$authors <- apply_directory_id_pairs(entry$authors, pairs)
-}
 
-path <- write_pkg(entry, packages_dir)
+# Pre-load CRAN once for all lookups; some requests may not need it but loading
+# it here avoids re-downloading per package.
+cran_db <- tryCatch(tools::CRAN_package_db(), error = function(e) NULL)
 
-cat("Wrote", path, "\n")
+succeeded <- list()
+failed <- list()
 
-# The workflow reads these on stdout to drive the branch name and PR body.
-gha_out <- Sys.getenv("GITHUB_OUTPUT", unset = "")
-if (nzchar(gha_out)) {
+for (req in requests) {
+  pkg_name <- req$name
+  owner_hint <- req$owner
+  cat("\n--- ", pkg_name, " ---\n", sep = "")
+
+  cand <- tryCatch(
+    lookup_one(pkg_name, owner_hint, repo_url_hint, cran_db),
+    error = function(e) {
+      cat("  error during lookup:", conditionMessage(e), "\n")
+      NULL
+    }
+  )
+
+  if (is.null(cand)) {
+    failed[[length(failed) + 1]] <- list(
+      name = pkg_name,
+      owner = owner_hint
+    )
+    next
+  }
+
+  entry <- to_package_shape(cand, dir_lookup)
+  if (length(pairs) > 0) {
+    entry$authors <- apply_directory_id_pairs(entry$authors, pairs)
+  }
+  path <- write_pkg(entry, packages_dir)
+  cat("  wrote", path, "\n")
+
   rel_path <- sub(
     paste0("^", here::here(), "/?"),
     "",
     path,
     fixed = FALSE
   )
-  writeLines(
-    c(
-      sprintf("file_path=%s", rel_path),
-      sprintf("package_name=%s", entry$name),
-      sprintf("source=%s", cand$source)
+  succeeded[[length(succeeded) + 1]] <- list(
+    name = entry$name,
+    file_path = rel_path,
+    source = cand$source
+  )
+}
+
+cat(
+  "\nSummary: ",
+  length(succeeded),
+  " succeeded, ",
+  length(failed),
+  " failed.\n",
+  sep = ""
+)
+
+gha_out <- Sys.getenv("GITHUB_OUTPUT", unset = "")
+if (nzchar(gha_out)) {
+  write_gha_output(
+    "file_paths",
+    vapply(succeeded, `[[`, character(1), "file_path"),
+    gha_out
+  )
+  write_gha_output(
+    "package_names",
+    vapply(succeeded, `[[`, character(1), "name"),
+    gha_out
+  )
+  write_gha_output(
+    "sources",
+    vapply(
+      succeeded,
+      function(s) sprintf("%s=%s", s$name, s$source),
+      character(1)
     ),
     gha_out
   )
+  write_gha_output(
+    "failed",
+    vapply(
+      failed,
+      function(f) {
+        sprintf(
+          "%s%s",
+          f$name,
+          if (nzchar(f$owner)) sprintf(" @ %s", f$owner) else ""
+        )
+      },
+      character(1)
+    ),
+    gha_out
+  )
+}
+
+# Fail the step only if nothing succeeded — partial successes still produce a PR.
+if (length(succeeded) == 0) {
+  stop("No packages could be looked up.")
 }


### PR DESCRIPTION
## Summary

- Issue template's **Package Name** input is now a **Packages** textarea — one package per line, with optional per-line `pkg @ owner` to override the default r-universe owner.
- `scripts/issue_to_package.R` loops over all requested packages, loading the CRAN db once. It tracks per-package successes and failures and emits multi-line workflow outputs (`file_paths`, `package_names`, `sources`, `failed`).
- Workflow stages every generated JSON in one commit on `auto/new-packages-<issue#>` and opens a single draft PR whose title/body adapt to N packages. Partial successes still produce a PR, with any lookups that failed called out at the top of the description so the submitter can follow up.

## Test plan

- [x] Multi-package partial success (one valid, one bogus) — succeeds and the failure is reported via the `failed` output.
- [x] Single-package CRAN fallback — works as before.
- [x] All-fail case — script exits non-zero so the lookup-failure comment fires.
- [x] Empty `Packages` field — bail-out comment fires before any R runs.
- [ ] End-to-end on the live workflow once merged — open a fresh `[New Package]` issue with two packages and confirm the draft PR contains both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)