### PR TITLE
Fix issue-form parser truncating multi-line textarea values

### DIFF
--- a/.github/workflows/new-content-issue.yaml
+++ b/.github/workflows/new-content-issue.yaml
@@ -34,7 +34,7 @@ jobs:
           script: |
             const body = process.env.ISSUE_BODY || '';
             const fields = {};
-            const re = /^###\s+(.+?)\s*\n+([\s\S]*?)(?=\n### |\n*$)/gm;
+            const re = /(?:^|\n)###\s+(.+?)\s*\n+([\s\S]*?)(?=\n### |$)/g;
             for (const m of body.matchAll(re)) {
               const key = m[1].trim().toLowerCase();
               let value = (m[2] || '').trim();

--- a/.github/workflows/new-package-issue.yaml
+++ b/.github/workflows/new-package-issue.yaml
@@ -34,7 +34,7 @@ jobs:
           script: |
             const body = process.env.ISSUE_BODY || '';
             const fields = {};
-            const re = /^###\s+(.+?)\s*\n+([\s\S]*?)(?=\n### |\n*$)/gm;
+            const re = /(?:^|\n)###\s+(.+?)\s*\n+([\s\S]*?)(?=\n### |$)/g;
             for (const m of body.matchAll(re)) {
               const key = m[1].trim().toLowerCase();
               let value = (m[2] || '').trim();


### PR DESCRIPTION
## Summary

- The shared issue-form parser used in [new-package-issue.yaml](.github/workflows/new-package-issue.yaml) and [new-content-issue.yaml](.github/workflows/new-content-issue.yaml) used a `gm` regex whose lookahead `\n*$` matched end-of-line (because of `m`), so the lazy section-content capture stopped at the end of the first line of any multi-line value.
- Single-line fields worked fine — that's why the bug stayed latent until the new multi-package textarea was introduced in #272.
- Fix: drop the `m` flag and switch the heading anchor from `^###` to `(?:^|\n)###`, so `$` is end-of-string and headings still anchor to a newline.

Caught when running an end-to-end test of #272 against issue #273 — the workflow bailed at "No packages listed" because the parser only captured the opening ` ```text ` line of the Packages textarea.

## Test plan

- [x] Reproduced the bug locally with the exact issue body and the old regex.
- [x] Verified the new regex captures all four sections fully on the same body.
- [ ] Re-run the workflow on a fresh test issue once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)