### PR TITLE
Open package-submission PRs as ready-for-review

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-package.yaml
+++ b/.github/ISSUE_TEMPLATE/new-package.yaml
@@ -11,7 +11,7 @@ body:
 
         Once you open this issue, a bot will look each package up on r-universe
         and CRAN, generate a JSON file under `data/packages/`, push them to a
-        new branch, and open a single draft pull request linked to this issue.
+        new branch, and open a single pull request linked to this issue.
         You'll be tagged on the PR so you can review the files (e.g. adding
         `directory_id` for additional authors) before they're merged.
   - type: textarea

--- a/.github/workflows/new-package-issue.yaml
+++ b/.github/workflows/new-package-issue.yaml
@@ -160,7 +160,7 @@ jobs:
           git commit -m "$msg"
           git push --force-with-lease origin "$BRANCH"
 
-      - name: Open or update draft PR
+      - name: Open or update PR
         if: steps.stage.outputs.changed == 'true'
         uses: actions/github-script@v7
         env:
@@ -244,8 +244,7 @@ jobs:
                 title,
                 head: branch,
                 base: context.payload.repository.default_branch,
-                body,
-                draft: true
+                body
               });
               pr = created.data;
               prCreated = true;
@@ -273,7 +272,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
-              body: `Hi @${author}, I drafted ${summary}${failNote} on branch \`${branch}\` and opened ${pr.html_url} for review. Take a look and request adjustments on the PR — fields like additional authors' \`directory_id\` may need a manual touch-up. I'm closing this issue; let's continue on the PR.`
+              body: `Hi @${author}, I added ${summary}${failNote} on branch \`${branch}\` and opened ${pr.html_url} for review. Take a look and request adjustments on the PR — fields like additional authors' \`directory_id\` may need a manual touch-up. I'm closing this issue; let's continue on the PR.`
             });
 
             if (prCreated) {


### PR DESCRIPTION
## Summary

- Drop `draft: true` from the auto-PR creation in [new-package-issue.yaml](.github/workflows/new-package-issue.yaml) so the PR opens ready for review.
- Update the wording in the issue template intro and the workflow's closing comment from "draft pull request" / "I drafted" to "pull request" / "I added".

The metadata pulled from r-universe/CRAN is generally usable as-is; submitters only need to touch up things like additional `directory_id`s. Opening as draft was extra friction without a clear benefit.

## Test plan

- [ ] Open a fresh `[New Package]` issue once merged and verify the resulting PR is open (not draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)