### PR TITLE
Spell out ready-for-review step in package-submission flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-package.yaml
+++ b/.github/ISSUE_TEMPLATE/new-package.yaml
@@ -11,9 +11,11 @@ body:
 
         Once you open this issue, a bot will look each package up on r-universe
         and CRAN, generate a JSON file under `data/packages/`, push them to a
-        new branch, and open a single draft pull request linked to this issue.
+        new branch, and open a single **draft** pull request linked to this issue.
         You'll be tagged on the PR so you can review the files (e.g. adding
-        `directory_id` for additional authors) before they're merged.
+        `directory_id` for additional authors). When the data looks good,
+        click **Ready for review** at the bottom of the PR — that's the signal
+        for maintainers to merge it.
   - type: textarea
     id: packages
     attributes:

--- a/.github/workflows/new-package-issue.yaml
+++ b/.github/workflows/new-package-issue.yaml
@@ -214,6 +214,10 @@ jobs:
             bodyParts.push(
               `@${author} please review the file(s) and request edits in this PR if anything is wrong (e.g. additional authors who need \`directory_id\`, missing logo, wrong description).`,
               ``,
+              `### :white_check_mark: When you're happy with the data`,
+              ``,
+              `This PR is **opened as a draft** so you have a chance to look over the auto-generated metadata first. Once it looks correct, click the **Ready for review** button at the bottom of the conversation — that's the signal to maintainers that it can be merged.`,
+              ``,
               `Closes #${issueNumber}.`
             );
             const body = bodyParts.join('\n');
@@ -273,7 +277,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
-              body: `Hi @${author}, I drafted ${summary}${failNote} on branch \`${branch}\` and opened ${pr.html_url} for review. Take a look and request adjustments on the PR — fields like additional authors' \`directory_id\` may need a manual touch-up. I'm closing this issue; let's continue on the PR.`
+              body: `Hi @${author}, I drafted ${summary}${failNote} on branch \`${branch}\` and opened ${pr.html_url} as a draft. Take a look — fields like additional authors' \`directory_id\` may need a manual touch-up. **When the data looks good, click _Ready for review_ at the bottom of the PR** so maintainers know it can be merged. I'm closing this issue; let's continue on the PR.`
             });
 
             if (prCreated) {


### PR DESCRIPTION
## Summary

Keep the auto-PR opened as a draft (so submitters review the auto-generated metadata first) but make the hand-off explicit instead of leaving it to convention. Three places now mention the Ready-for-review button:

- [.github/ISSUE_TEMPLATE/new-package.yaml](.github/ISSUE_TEMPLATE/new-package.yaml) — intro reframes the PR as a draft and tells submitters to click **Ready for review** when satisfied.
- [.github/workflows/new-package-issue.yaml](.github/workflows/new-package-issue.yaml) — auto-PR body adds a `### :white_check_mark: When you're happy with the data` section pointing at the button.
- The closing comment on the originating issue says the same in one sentence so submitters see it without having to open the PR first.

This supersedes #276 (which removed the draft entirely).

## Test plan

- [ ] Open a `[New Package]` issue once merged and confirm: PR is a draft, has the new instruction section, and the issue comment includes the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)