### PR TITLE
Add R-Ladies Global blog to content

### DIFF
--- a/data/content/rladies.org.json
+++ b/data/content/rladies.org.json
@@ -1,0 +1,18 @@
+{
+  "title": "R-Ladies Global Blog",
+  "type": "blog",
+  "url": "https://rladies.org/blog/",
+  "rss_feed": "https://rladies.org/blog/index.xml",
+  "photo_url": "https://rladies.org/images/og-default.png",
+  "description": "News, tutorials, and stories from the R-Ladies+ community — written by chapter organisers, members, and contributors around the world.",
+  "language": "en",
+  "authors": [
+    {
+      "name": "R-Ladies Global",
+      "social_media": [{
+        "github": "rladies",
+        "website": "https://rladies.org/"
+      }]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `data/content/rladies.org.json` for the R-Ladies Global blog at https://rladies.org/blog/
- Includes RSS feed (`/blog/index.xml`), og:image, and description scraped from the site

## Test plan
- [ ] JSON validation passes
- [ ] Aggregated website JSONs pick up the new entry on next build

🤖 Generated with [Claude Code](https://claude.com/claude-code)