### PR TITLE
Switch from PAT to Jinx GitHub App

### DIFF
--- a/.github/workflows/trigger-website.yaml
+++ b/.github/workflows/trigger-website.yaml
@@ -13,11 +13,18 @@ jobs:
     name: Trigger
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.JINX_APP_ID }}
+          private-key: ${{ secrets.JINX_PRIVATE_KEY }}
+          owner: rladies
 
       - name: Trigger test build
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GLOBAL_GHA_PAT }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'rladies',


### PR DESCRIPTION
## Summary
- Replace `GLOBAL_GHA_PAT` with `actions/create-github-app-token` in the `trigger-website` workflow
- Cross-repo dispatch to `rladies.github.io` now uses the Jinx org app token

## Test plan
- [ ] Open a PR touching `data/website/` and verify it triggers a website preview build

🤖 Generated with [Claude Code](https://claude.com/claude-code)