### PR TITLE
Use Jinx app token for all comments and commits

### DIFF
--- a/.github/workflows/check-urls.yaml
+++ b/.github/workflows/check-urls.yaml
@@ -18,6 +18,14 @@ jobs:
   sweep:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.JINX_APP_ID }}
+          private-key: ${{ secrets.JINX_PRIVATE_KEY }}
+          owner: rladies
+
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
@@ -47,6 +55,7 @@ jobs:
           ISSUE_TITLE: "Broken URLs sweep"
           DOWN_STREAK_THRESHOLD: "2"
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
             const reportPath = process.env.REPORT_PATH;
@@ -178,6 +187,7 @@ jobs:
         env:
           REPORT_PATH: url-check-report.tsv
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
             const path = require('path');
@@ -216,15 +226,15 @@ jobs:
       - name: Open or update og:image fix PR
         if: steps.fixes.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BRANCH: auto/og-image-fixes
           COUNT: ${{ steps.fixes.outputs.count }}
           SUMMARY: ${{ steps.fixes.outputs.summary }}
           ISSUE_NUMBER: ${{ steps.issue.outputs.issue_number }}
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "Jinx[bot]"
+          git config user.email "jinx@rladies.org"
           git checkout -B "$BRANCH"
           git add data/
           git commit -m "Replace ${COUNT} broken image URL(s) with og:image suggestions"

--- a/.github/workflows/new-content-issue.yaml
+++ b/.github/workflows/new-content-issue.yaml
@@ -20,6 +20,14 @@ jobs:
       (github.event.action == 'labeled' && github.event.label.name == 'content-submission')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.JINX_APP_ID }}
+          private-key: ${{ secrets.JINX_PRIVATE_KEY }}
+          owner: rladies
+
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
@@ -70,6 +78,7 @@ jobs:
           steps.parse.outputs.author_name == ''
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -120,6 +129,7 @@ jobs:
         env:
           URL: ${{ steps.parse.outputs.content_url }}
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const url = process.env.URL;
             await github.rest.issues.createComment({
@@ -155,6 +165,7 @@ jobs:
         env:
           FILE_PATH: ${{ steps.branch.outputs.file }}
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const file = process.env.FILE_PATH;
             await github.rest.issues.createComment({
@@ -169,15 +180,15 @@ jobs:
       - name: Push branch
         if: steps.branch.outputs.changed == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           BRANCH: ${{ steps.branch.outputs.branch }}
           FILE_PATH: ${{ steps.branch.outputs.file }}
           FILENAME: ${{ steps.generate.outputs.filename }}
           ISSUE: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "Jinx[bot]"
+          git config user.email "jinx@rladies.org"
           git checkout -b "$BRANCH"
           git add "$FILE_PATH"
           git commit -m "Add ${FILENAME} (issue #${ISSUE})"
@@ -192,6 +203,7 @@ jobs:
           FILENAME: ${{ steps.generate.outputs.filename }}
           CONTENT_TYPE: ${{ steps.generate.outputs.content_type }}
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const branch = process.env.BRANCH;
             const file = process.env.FILE_PATH;

--- a/.github/workflows/new-package-issue.yaml
+++ b/.github/workflows/new-package-issue.yaml
@@ -20,6 +20,14 @@ jobs:
       (github.event.action == 'labeled' && github.event.label.name == 'package-submission')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.JINX_APP_ID }}
+          private-key: ${{ secrets.JINX_PRIVATE_KEY }}
+          owner: rladies
+
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
@@ -58,6 +66,7 @@ jobs:
         if: steps.parse.outputs.pkg_names == ''
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -97,6 +106,7 @@ jobs:
           PKG_NAMES: ${{ steps.parse.outputs.pkg_names }}
           PKG_OWNER: ${{ steps.parse.outputs.pkg_owner }}
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const list = (process.env.PKG_NAMES || '')
               .split('\n').map(l => l.trim()).filter(Boolean)
@@ -130,6 +140,7 @@ jobs:
         if: steps.stage.outputs.changed == 'false'
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -148,8 +159,8 @@ jobs:
           PKG_NAMES_OUT: ${{ steps.generate.outputs.package_names }}
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "Jinx[bot]"
+          git config user.email "jinx@rladies.org"
           git checkout -b "$BRANCH"
           count=$(printf '%s\n' "$PKG_NAMES_OUT" | grep -c . || true)
           if [ "$count" = "1" ]; then
@@ -170,6 +181,7 @@ jobs:
           SOURCES: ${{ steps.generate.outputs.sources }}
           FAILED: ${{ steps.generate.outputs.failed }}
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const branch = process.env.BRANCH;
             const pkgs = (process.env.PKG_NAMES_OUT || '').split('\n').filter(Boolean);

--- a/.github/workflows/trigger-website.yaml
+++ b/.github/workflows/trigger-website.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Notify about build start
         uses: actions/github-script@v7
         with:
-            github-token: ${{ secrets.GITHUB_TOKEN }}
+            github-token: ${{ steps.app-token.outputs.token }}
             script: |
                 const path = require('path');
                 await github.rest.issues.createComment({


### PR DESCRIPTION
## Summary
- Replace `secrets.GITHUB_TOKEN` with Jinx app token across trigger-website, new-content-issue, new-package-issue, and check-urls workflows
- Update git commit identity to `Jinx[bot]` (jinx@rladies.org)
- All issue/PR comments and commits now appear as Jinx[bot]

## Test plan
- [ ] Open a content-submission issue and verify comments appear as Jinx[bot]
- [ ] Open a package-submission issue and verify comments appear as Jinx[bot]
- [ ] Trigger check-urls and verify issue/PR creation is as Jinx[bot]

🤖 Generated with [Claude Code](https://claude.com/claude-code)