### PR TITLE
Adopt jinx reusable workflows for welcome and thank

### DIFF
--- a/.github/workflows/hello.yaml
+++ b/.github/workflows/hello.yaml
@@ -6,6 +6,10 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   welcome:
     if: github.event.action == 'opened'

--- a/.github/workflows/hello.yaml
+++ b/.github/workflows/hello.yaml
@@ -1,18 +1,22 @@
-name: "Auto message for PR's and Issues"
-on: [pull_request, issues]
+name: Hello on PR or Issue
+
+on:
+  pull_request:
+    types: [opened, closed]
+  issues:
+    types: [opened]
 
 jobs:
-  send-message:
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.merged
-    steps:
-      - uses: actions/github-script@v7
-        name: send-message
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `Hey, thank you for opening your Pull Request ! 🙂 We will get to this as soon as we can!`
-            })
+  welcome:
+    if: github.event.action == 'opened'
+    uses: rladies/jinx/.github/workflows/reusable-welcome-contributor.yml@main
+    secrets:
+      JINX_APP_ID: ${{ secrets.JINX_APP_ID }}
+      JINX_PRIVATE_KEY: ${{ secrets.JINX_PRIVATE_KEY }}
+
+  thank:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    uses: rladies/jinx/.github/workflows/reusable-thank-contributor.yml@main
+    secrets:
+      JINX_APP_ID: ${{ secrets.JINX_APP_ID }}
+      JINX_PRIVATE_KEY: ${{ secrets.JINX_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Replaces the single 19-line job that posts a generic "thank you for opening" comment on every merged PR with two delegations to the [rladies/jinx](https://github.com/rladies/jinx) reusable workflows:

- \`reusable-welcome-contributor.yml\` on PR/issue open — bot-skip, team-member-skip, first-time-contributor detection, jinx-branded welcome message.
- \`reusable-thank-contributor.yml\` on PR merge — first-time-vs-returning message variants.

Same pattern as [rladies/rladies.github.io#592](https://github.com/rladies/rladies.github.io/pull/592). Keeps comment maintenance in one canonical place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)