### PR TITLE
Switch hello trigger to pull_request_target

### DIFF
--- a/.github/workflows/hello.yaml
+++ b/.github/workflows/hello.yaml
@@ -1,7 +1,7 @@
 name: Hello on PR or Issue
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, closed]
   issues:
     types: [opened]
@@ -19,7 +19,7 @@ jobs:
       JINX_PRIVATE_KEY: ${{ secrets.JINX_PRIVATE_KEY }}
 
   thank:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    if: github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true
     uses: rladies/jinx/.github/workflows/reusable-thank-contributor.yml@main
     secrets:
       JINX_APP_ID: ${{ secrets.JINX_APP_ID }}


### PR DESCRIPTION
## Summary

Fork-PR welcomes/thanks were failing because `pull_request` events from forks run with a read-only token and no secrets access — the jinx app token can't be minted, so the workflow dies before posting.

Switching to `pull_request_target` runs the workflow in the upstream repo's context with full secrets access, so the welcome/thank/checklist comments fire on fork PRs too.

## Security note

`pull_request_target` is normally a footgun because it runs with secrets in the upstream context while looking at fork code. The risk only materialises if the workflow **checks out the PR head** and runs code from it.

This workflow does neither — it only mints a jinx app token and posts a comment via the GitHub API. Untrusted PR code is never executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)