### PR TITLE
Pilot R-Universe opt-ins: Athanasia Mowinckel, Steffi LaZerte

### DIFF
--- a/data/runiverse/drmowinckels.json
+++ b/data/runiverse/drmowinckels.json
@@ -1,0 +1,4 @@
+{
+  "handle": "drmowinckels",
+  "directory_id": "athanasia-mo-mowinckel"
+}

--- a/data/runiverse/steffilazerte.json
+++ b/data/runiverse/steffilazerte.json
@@ -1,0 +1,4 @@
+{
+  "handle": "steffilazerte",
+  "directory_id": "steffi-lazerte"
+}


### PR DESCRIPTION
## Summary

- Register two pilot opt-ins for the new R-Universe sync flow added in #284.
- `data/runiverse/drmowinckels.json` → `drmowinckels.r-universe.dev` (Athanasia Mowinckel, `athanasia-mo-mowinckel`).
- `data/runiverse/steffilazerte.json` → `steffilazerte.r-universe.dev` (Steffi LaZerte, `steffi-lazerte`).

Neither `packages.json` currently has `"rladies": true` on any entry, so the first cron run will be a no-op. The pilot users can flag a package at a time and watch the sync workflow pick them up.

## Test plan

- [x] `Rscript scripts/validate_jsons.R` — `data/runiverse/` validates against `runiverse.json` (2/2).
- [ ] Once merged, run `Sync packages from R-Universe opt-ins` via workflow dispatch — expect a no-op until either author flags a package.
- [ ] Add `"rladies": true` to one entry in `drmowinckels.r-universe.dev/packages.json` and re-dispatch; expect a direct commit to main with the new `data/packages/<pkg>.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)